### PR TITLE
feat: implement shared package folder for other packages

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,9 @@ export default defineConfig([
     languageOptions: {
       globals: { ...globals.node },
       parserOptions: {
-        projectService: true,
+        projectService: {
+          allowDefaultProject: ['vitest.config.ts', 'packages/*/tests/*.test.ts'],
+        },
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
     "@types/node": "^25.5.0",
+    "@vitest/coverage-v8": "4.1.4",
     "eslint": "^10.1.0",
     "globals": "^17.4.0",
     "husky": "^9.1.7",

--- a/packages/parser/Readme.md
+++ b/packages/parser/Readme.md
@@ -1,0 +1,62 @@
+# `@mindfiredigital/mdslide-parser`
+
+Parses a Markdown string into a structured array of `Slide` objects, ready to be consumed by a slide renderer. It handles slide splitting, heading extraction, and automatic layout detection.
+
+---
+
+## How It Works
+
+The parser runs the input through three sequential steps:
+
+1. **Parse** — The raw Markdown string is parsed into an [mdast](https://github.com/syntax-tree/mdast) AST using [`remark-parse`](https://github.com/remarkjs/remark/tree/main/packages/remark-parse).
+2. **Split** — The AST is walked to split content into individual slides.
+3. **Detect Layout** — Each slide is inspected and assigned a layout type based on its content.
+
+---
+
+## Slide Splitting Rules
+
+| Markdown construct           | Behavior                                                                           |
+| ---------------------------- | ---------------------------------------------------------------------------------- |
+| `# H1` at the top of a slide | Sets the `title` of the current slide                                              |
+| `## H2`                      | Ends the current slide and starts a new one, using the heading text as its `title` |
+| `***` (thematic break)       | Ends the current slide and starts a new blank one                                  |
+| Any other node               | Appended to the `content` array of the current slide                               |
+
+---
+
+## Layout Detection
+
+After splitting, each slide is assigned one of three `type` values:
+
+| Type        | Condition                                         |
+| ----------- | ------------------------------------------------- |
+| `"title"`   | Slide has a `title` and no `content`              |
+| `"bullets"` | Slide `content` contains at least one `list` node |
+| `"content"` | Default — everything else                         |
+
+---
+
+## Package Info
+
+| Field             | Value                             |
+| ----------------- | --------------------------------- |
+| Package name      | `@mindfiredigital/mdslide-parser` |
+| Module format     | ESM (`"type": "module"`)          |
+| Entry point       | `dist/index.js`                   |
+| Type declarations | `dist/index.d.ts`                 |
+
+---
+
+## Development
+
+```bash
+# Build once
+pnpm build
+
+# Watch mode
+pnpm dev
+
+# Clean build output
+pnpm clean
+```

--- a/packages/parser/Readme.md
+++ b/packages/parser/Readme.md
@@ -8,7 +8,7 @@ Parses a Markdown string into a structured array of `Slide` objects, ready to be
 
 The parser runs the input through three sequential steps:
 
-1. **Parse** — The raw Markdown string is parsed into an [mdast](https://github.com/syntax-tree/mdast) AST using [`remark-parse`](https://github.com/remarkjs/remark/tree/main/packages/remark-parse).
+1. **Parse** — The raw Markdown string is parsed into an  AST using [`remark-parse`](https://github.com/remarkjs/remark/tree/main/packages/remark-parse).
 2. **Split** — The AST is walked to split content into individual slides.
 3. **Detect Layout** — Each slide is inspected and assigned a layout type based on its content.
 

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -17,5 +17,9 @@
     "@mindfiredigital/mdslide-shared": "workspace:*",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.5"
+  },
+  "devDependencies": {
+    "@types/mdast": "^4.0.4",
+    "@types/node": "^25.6.0"
   }
 }

--- a/packages/parser/src/detect-layout.ts
+++ b/packages/parser/src/detect-layout.ts
@@ -1,0 +1,22 @@
+import { Slide } from '@mindfiredigital/mdslide-shared';
+
+export function detectLayout(slide: Slide): Slide {
+  //covert to bullet
+  const hasList = slide.content.some((item) => item.type === 'list');
+
+  if (hasList) {
+    return {
+      ...slide,
+      type: 'bullets',
+    };
+  }
+
+  //covert to main title
+  if (slide.title && slide.content.length === 0) {
+    return {
+      ...slide,
+      type: 'title',
+    };
+  }
+  return slide;
+}

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -1,0 +1,3 @@
+export { parse } from './parse.js';
+export { splitSlides } from './split.js';
+export { detectLayout } from './detect-layout.js';

--- a/packages/parser/src/parse.ts
+++ b/packages/parser/src/parse.ts
@@ -1,0 +1,14 @@
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import type { Root } from 'mdast';
+import type { Slide } from '@mindfiredigital/mdslide-shared';
+
+import { splitSlides } from './split.js';
+import { detectLayout } from './detect-layout.js';
+
+export function parse(markdown: string): Slide[] {
+  const tree = unified().use(remarkParse).parse(markdown) as Root;
+
+  const slides = splitSlides(tree);
+  return slides.map(detectLayout);
+}

--- a/packages/parser/src/split.ts
+++ b/packages/parser/src/split.ts
@@ -1,0 +1,67 @@
+import type { Root, RootContent } from 'mdast';
+import type { Slide, SlideNode } from '@mindfiredigital/mdslide-shared';
+
+// converts the mdast content to a plane slidenode
+function toNode(node: RootContent): SlideNode {
+  return {
+    type: node.type,
+    value: 'value' in node ? String(node.value) : undefined,
+    children:
+      'children' in node ? node.children.map((child: RootContent) => toNode(child)) : undefined,
+  };
+}
+
+export function splitSlides(tree: Root): Slide[] {
+  const slides: Slide[] = [];
+
+  // Start the first slide
+  let current: Slide = {
+    id: globalThis.crypto.randomUUID(),
+    type: 'content',
+    content: [],
+  };
+
+  for (const node of tree.children) {
+    //For thematic break '***' stop present slide go to new one
+    if (node.type === 'thematicBreak') {
+      slides.push(current);
+      current = {
+        id: globalThis.crypto.randomUUID(),
+        type: 'content',
+        content: [],
+      };
+      continue;
+    }
+
+    if (node.type === 'heading') {
+      // Pull the raw text out of first child
+      const text =
+        node.children.length > 0 && 'value' in node.children[0]
+          ? String(node.children[0].value)
+          : '';
+
+      // for ## H2
+      if (node.depth === 2) {
+        slides.push(current);
+        current = {
+          id: globalThis.crypto.randomUUID(),
+          type: 'content',
+          title: text,
+          content: [],
+        };
+        continue;
+      }
+
+      // for # H1
+      if (node.depth === 1) {
+        current.title = text;
+        continue;
+      }
+    }
+
+    current.content.push(toNode(node));
+  }
+  slides.push(current);
+
+  return slides;
+}

--- a/packages/parser/tests/detect-layout.test.ts
+++ b/packages/parser/tests/detect-layout.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { detectLayout } from '../src/detect-layout.js';
+import { Slide } from '@mindfiredigital/mdslide-shared';
+
+describe('detectLayout', () => {
+  it('should detect bullets layout', () => {
+    const slide: Slide = {
+      id: '1',
+      type: 'content',
+      content: [{ type: 'list' }],
+    };
+    const result = detectLayout(slide);
+    expect(result.type).toBe('bullets');
+  });
+
+  it('detects title layout', () => {
+    const slide: Slide = {
+      id: '2',
+      type: 'content',
+      title: 'Title-only',
+      content: [],
+    };
+    const result = detectLayout(slide);
+    expect(result.type).toBe('title');
+  });
+
+  it('should return the slide if there is no layout', () => {
+    const slide: Slide = {
+      id: '3',
+      type: 'content',
+      content: [{ type: 'text' }],
+    };
+
+    const result = detectLayout(slide);
+    expect(result.type).toBe('content');
+  });
+});

--- a/packages/parser/tests/parse.test.ts
+++ b/packages/parser/tests/parse.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from '../src/parse.js';
+
+describe('parse', () => {
+  it('parse a simple paragraph to slide', () => {
+    const result = parse('hello world');
+    expect(result).toHaveLength(1);
+    expect(result[0].content[0].type).toBe('paragraph');
+  });
+
+  it('---  : splits into two slides', () => {
+    const result = parse(`
+first slide
+---
+second slide
+        `);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('# sets the title on the slide', () => {
+    const result = parse(`
+# My Presentation
+
+some content
+        `);
+
+    expect(result[0].title).toBe('My Presentation');
+  });
+
+  it('## starts a new slide with that title', () => {
+    const result = parse(`
+## Intro
+
+some content
+        `);
+
+    const slide = result.find((s) => s.title === 'Intro');
+    expect(slide).toBeDefined();
+    expect(slide!.content[0].type).toBe('paragraph');
+  });
+
+  it('bullet list is present then slide detected as bullets layout', () => {
+    const result = parse(`
+## Features
+
+- fast
+- simple
+- reliable
+        `);
+
+    const slide = result.find((s) => s.title === 'Features');
+    expect(slide).toBeDefined();
+    expect(slide!.type).toBe('bullets');
+  });
+
+  it('title is present then slide detected as title layout', () => {
+    const result = parse('# My Presentation');
+    expect(result[0].type).toBe('title');
+  });
+});

--- a/packages/parser/tests/split.test.ts
+++ b/packages/parser/tests/split.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { splitSlides } from '../src/split.js';
+import type { Root } from 'mdast';
+
+describe('splitSlides', () => {
+  it('plain paragraph ends up in one slide', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'paragraph', children: [{ type: 'text', value: 'hi-rushik' }] }],
+    };
+
+    const result = splitSlides(tree);
+    expect(result).toHaveLength(1);
+    expect(result[0].content[0].type).toBe('paragraph');
+  });
+
+  it('thematic break which creates two slides', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        { type: 'paragraph', children: [{ type: 'text', value: 'slide-1' }] },
+        { type: 'thematicBreak' },
+        { type: 'paragraph', children: [{ type: 'text', value: 'slide-2' }] },
+      ],
+    };
+
+    const result = splitSlides(tree);
+    expect(result).toHaveLength(2);
+  });
+
+  it('## starts a new slide and becomes its title', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        { type: 'heading', depth: 2, children: [{ type: 'text', value: 'Main' }] },
+        { type: 'paragraph', children: [{ type: 'text', value: 'Para' }] },
+      ],
+    };
+
+    const result = splitSlides(tree);
+    const slide = result.find((s) => s.title === 'Main');
+    expect(slide).toBeDefined();
+    expect(slide!.content[0].type).toBe('paragraph');
+  });
+
+  it('# sets as main title ', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        { type: 'heading', depth: 1, children: [{ type: 'text', value: 'My Presentation' }] },
+        { type: 'paragraph', children: [{ type: 'text', value: 'some content' }] },
+      ],
+    };
+
+    const result = splitSlides(tree);
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('My Presentation');
+  });
+
+  it('every slide gets its own id', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'thematicBreak' }, { type: 'thematicBreak' }],
+    };
+
+    const result = splitSlides(tree);
+    const ids = result.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/packages/parser/tests/split.test.ts
+++ b/packages/parser/tests/split.test.ts
@@ -28,7 +28,7 @@ describe('splitSlides', () => {
     expect(result).toHaveLength(2);
   });
 
-  it('## starts a new slide and becomes its title', () => {
+  it('## starts a new slide and also becomes a new title', () => {
     const tree: Root = {
       type: 'root',
       children: [
@@ -43,7 +43,7 @@ describe('splitSlides', () => {
     expect(slide!.content[0].type).toBe('paragraph');
   });
 
-  it('# sets as main title ', () => {
+  it('# sets the main title ', () => {
     const tree: Root = {
       type: 'root',
       children: [
@@ -57,7 +57,7 @@ describe('splitSlides', () => {
     expect(result[0].title).toBe('My Presentation');
   });
 
-  it('every slide gets its own id', () => {
+  it('every slide should have its own id', () => {
     const tree: Root = {
       type: 'root',
       children: [{ type: 'thematicBreak' }, { type: 'thematicBreak' }],

--- a/packages/shared/src/ast.ts
+++ b/packages/shared/src/ast.ts
@@ -1,0 +1,10 @@
+import { Slide } from './types.js';
+
+export function createSlide(partial: Partial<Slide>): Slide {
+  return {
+    id: crypto.randomUUID(),
+    type: 'content',
+    content: [],
+    ...partial,
+  };
+}

--- a/packages/shared/src/ast.ts
+++ b/packages/shared/src/ast.ts
@@ -2,7 +2,7 @@ import { Slide } from './types.js';
 
 export function createSlide(partial: Partial<Slide>): Slide {
   return {
-    id: crypto.randomUUID(),
+    id: globalThis.crypto.randomUUID(),
     type: 'content',
     content: [],
     ...partial,

--- a/packages/shared/src/frontmatter.ts
+++ b/packages/shared/src/frontmatter.ts
@@ -1,0 +1,10 @@
+import matter from 'gray-matter';
+
+export function parseFrontmatter(md: string) {
+  const { data, content } = matter(md);
+
+  return {
+    meta: data || {},
+    content,
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,3 @@
+export * from './types.js';
+export * from './ast.js';
+export * from './frontmatter.js';

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,20 @@
+export type SlideType = 'title' | 'bullets' | 'content';
+
+export interface SlideNode {
+  type: string;
+  value?: string;
+  children?: SlideNode[];
+}
+
+export interface Slide {
+  id: string;
+  type: SlideType;
+  title?: string;
+  content: SlideNode[];
+  notes?: string;
+}
+
+export interface SlideDeck {
+  meta?: Record<string, unknown>;
+  slides: Slide[];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@types/node':
         specifier: ^25.5.0
         version: 25.6.0
+      '@vitest/coverage-v8':
+        specifier: 4.1.4
+        version: 4.1.4(vitest@4.1.4)
       eslint:
         specifier: ^10.1.0
         version: 10.2.0(jiti@2.6.1)
@@ -43,7 +46,7 @@ importers:
         version: 8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.4(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
 
   packages/parser:
     dependencies:
@@ -76,9 +79,26 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@commitlint/cli@20.5.0':
     resolution: {integrity: sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ==}
@@ -226,6 +246,9 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -452,6 +475,15 @@ packages:
     resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/coverage-v8@4.1.4':
+    resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
+    peerDependencies:
+      '@vitest/browser': 4.1.4
+      vitest: 4.1.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.4':
     resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
 
@@ -536,6 +568,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -824,6 +859,13 @@ packages:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
@@ -886,9 +928,24 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1041,6 +1098,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -1306,6 +1370,10 @@ packages:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1523,7 +1591,20 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@commitlint/cli@20.5.0(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
     dependencies:
@@ -1711,6 +1792,11 @@ snapshots:
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
@@ -1918,6 +2004,20 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.4
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
+
   '@vitest/expect@4.1.4':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2008,6 +2108,12 @@ snapshots:
   array-ify@1.0.0: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   bail@2.0.2: {}
 
@@ -2276,6 +2382,10 @@ snapshots:
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
+  has-flag@4.0.0: {}
+
+  html-escaper@2.0.2: {}
+
   husky@9.1.7: {}
 
   ignore@5.3.2: {}
@@ -2315,7 +2425,22 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@2.6.1: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -2445,6 +2570,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   make-error@1.3.6: {}
 
@@ -2783,6 +2918,10 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.1: {}
@@ -2883,7 +3022,7 @@ snapshots:
       jiti: 2.6.1
       yaml: 2.8.3
 
-  vitest@4.1.4(@types/node@25.6.0)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)):
+  vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
@@ -2907,6 +3046,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,13 @@ importers:
       unified:
         specifier: ^11.0.5
         version: 11.0.5
+    devDependencies:
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
 
   packages/shared:
     dependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,11 +11,10 @@
     "sourceMap": true,
     "forceConsistentCasingInFileNames": true,
 
-    "baseUrl": ".",
     "paths": {
-      "@mindfiredigital/mdslide-*": ["packages/*/src"]
+      "@mindfiredigital/mdslide-*": ["./packages/*/src"]
     },
 
-    "ignoreDeprecations": "6.0"
+    "ignoreDeprecations": "5.0"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Description:
Implemented shared packages in **packages**  folder for my parser and remaining packages which i work in future(like renderer,cli etc;) so , I have added files ast.ts,frontmatter.ts ,types.ts and add `@mindfiredigital/mdslide-shared: workspace` this to dependencies of remaining packages and also implemented `detect-layout.ts`  `split.ts` and `parse.ts` files of parser module in **packages** and along with test cases `detect-layout.test.ts` , `split.test.ts` and `parse.test.ts` including a readme.md file for clear info about my package

## Related Issue:
Closes #4 and #5 
## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing functionality)
- [ ] Documentation update

## Checklist
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] I have updated the documentation accordingly
- [x] My changes generate no new TypeScript errors (`pnpm build` passes)
- [x] Relevant package `index.ts` exports are updated
- [x] No circular dependencies introduced between packages