### PR TITLE
Implemented frontmatter extraction, speakernotes extraction and included manual layoutoverride

### DIFF
--- a/packages/parser/src/detect-layout.ts
+++ b/packages/parser/src/detect-layout.ts
@@ -1,6 +1,13 @@
-import { Slide } from '@mindfiredigital/mdslide-shared';
+import { Slide, SlideType } from '@mindfiredigital/mdslide-shared';
 
 export function detectLayout(slide: Slide): Slide {
+  //manual overide
+  if (slide.layoutOverride) {
+    return {
+      ...slide,
+      type: slide.layoutOverride as SlideType,
+    };
+  }
   //covert to bullet
   const hasList = slide.content.some((item) => item.type === 'list');
 

--- a/packages/parser/src/parse.ts
+++ b/packages/parser/src/parse.ts
@@ -1,14 +1,15 @@
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import type { Root } from 'mdast';
-import type { Slide } from '@mindfiredigital/mdslide-shared';
+import type { SlideDeck } from '@mindfiredigital/mdslide-shared';
+import { parseFrontmatter } from '@mindfiredigital/mdslide-shared';
 
 import { splitSlides } from './split.js';
 import { detectLayout } from './detect-layout.js';
 
-export function parse(markdown: string): Slide[] {
-  const tree = unified().use(remarkParse).parse(markdown) as Root;
-
-  const slides = splitSlides(tree);
-  return slides.map(detectLayout);
+export function parse(markdown: string): SlideDeck {
+  const { meta, content } = parseFrontmatter(markdown);
+  const tree = unified().use(remarkParse).parse(content) as Root;
+  const slides = splitSlides(tree).map(detectLayout);
+  return { meta, slides };
 }

--- a/packages/parser/src/split.ts
+++ b/packages/parser/src/split.ts
@@ -36,69 +36,76 @@ function freshSlide(title?: string): Slide {
 }
 
 export function splitSlides(tree: Root): Slide[] {
+  if (!tree.children || tree.children.length === 0) return [];
+
   const slides: Slide[] = [];
   let current: Slide = freshSlide();
   let inNotes = false;
 
-  for (const node of tree.children) {
-    // For thematic break '***' stop present slide go to new one
-    if (node.type === 'thematicBreak') {
-      slides.push(current);
-      current = freshSlide();
-      inNotes = false;
-      continue;
-    }
-
-    // html comments, notes and layout override
-    if (node.type === 'html') {
-      const val = node.value.trim();
-
-      if (val === '<!-- notes -->') {
-        inNotes = true;
-        continue;
-      }
-
-      if (val === '<!-- /notes -->') {
+  try {
+    for (const node of tree.children) {
+      // For thematic break '***' stop present slide go to new one
+      if (node.type === 'thematicBreak') {
+        slides.push(current);
+        current = freshSlide();
         inNotes = false;
         continue;
       }
 
-      const layoutMatch = val.match(/^<!--\s*layout:\s*(\w+)\s*-->$/);
-      if (layoutMatch) {
-        current.layoutOverride = layoutMatch[1];
+      // html comments, notes and layout override
+      if (node.type === 'html') {
+        const val = node.value.trim();
+
+        if (val === '<!-- notes -->') {
+          inNotes = true;
+          continue;
+        }
+
+        if (val === '<!-- /notes -->') {
+          inNotes = false;
+          continue;
+        }
+
+        const layoutMatch = val.match(/^<!--\s*layout:\s*(\w+)\s*-->$/);
+        if (layoutMatch) {
+          current.layoutOverride = layoutMatch[1];
+          continue;
+        }
+      }
+
+      // collect text into notes field while inside a notes block
+      if (inNotes) {
+        const text = extractText(node).trim();
+        if (text) {
+          current.notes = current.notes ? `${current.notes}\n${text}` : text;
+        }
         continue;
       }
-    }
 
-    // collect text into notes field while inside a notes block
-    if (inNotes) {
-      const text = extractText(node).trim();
-      if (text) {
-        current.notes = current.notes ? `${current.notes}\n${text}` : text;
-      }
-      continue;
-    }
+      // headings control slide boundaries and titles
+      if (node.type === 'heading') {
+        const text = headingText(node);
 
-    // headings control slide boundaries and titles
-    if (node.type === 'heading') {
-      const text = headingText(node);
+        // ## for H2
+        if (node.depth === 2) {
+          slides.push(current);
+          current = freshSlide(text);
+          continue;
+        }
 
-      // ## for H2
-      if (node.depth === 2) {
-        slides.push(current);
-        current = freshSlide(text);
-        continue;
+        // # for H1
+        if (node.depth === 1) {
+          current.title = text;
+          continue;
+        }
       }
 
-      // # for H1
-      if (node.depth === 1) {
-        current.title = text;
-        continue;
-      }
+      current.content.push(toNode(node));
     }
-
-    current.content.push(toNode(node));
+  } catch (err) {
+    throw new Error(`Failed to split slides: ${err instanceof Error ? err.message : String(err)}`);
   }
+
   slides.push(current);
-  return slides;
+  return slides.filter((s) => s.title !== undefined || s.content.length > 0);
 }

--- a/packages/parser/src/split.ts
+++ b/packages/parser/src/split.ts
@@ -1,4 +1,4 @@
-import type { Root, RootContent } from 'mdast';
+import type { Root, RootContent, Heading } from 'mdast';
 import type { Slide, SlideNode } from '@mindfiredigital/mdslide-shared';
 
 // converts the mdast content to a plane slidenode
@@ -11,48 +11,86 @@ function toNode(node: RootContent): SlideNode {
   };
 }
 
-export function splitSlides(tree: Root): Slide[] {
-  const slides: Slide[] = [];
+// extract text plain text
+function extractText(node: RootContent): string {
+  if ('value' in node) return String(node.value);
+  if ('children' in node) return node.children.map(extractText).join(' ');
+  return '';
+}
 
-  // Start the first slide
-  let current: Slide = {
+// extract plain text from a heading node
+function headingText(node: Heading): string {
+  return node.children.length > 0 && 'value' in node.children[0]
+    ? String(node.children[0].value)
+    : '';
+}
+
+// start with new slide
+function freshSlide(title?: string): Slide {
+  return {
     id: globalThis.crypto.randomUUID(),
     type: 'content',
     content: [],
+    ...(title && { title }),
   };
+}
+
+export function splitSlides(tree: Root): Slide[] {
+  const slides: Slide[] = [];
+  let current: Slide = freshSlide();
+  let inNotes = false;
 
   for (const node of tree.children) {
-    //For thematic break '***' stop present slide go to new one
+    // For thematic break '***' stop present slide go to new one
     if (node.type === 'thematicBreak') {
       slides.push(current);
-      current = {
-        id: globalThis.crypto.randomUUID(),
-        type: 'content',
-        content: [],
-      };
+      current = freshSlide();
+      inNotes = false;
       continue;
     }
 
-    if (node.type === 'heading') {
-      // Pull the raw text out of first child
-      const text =
-        node.children.length > 0 && 'value' in node.children[0]
-          ? String(node.children[0].value)
-          : '';
+    // html comments, notes and layout override
+    if (node.type === 'html') {
+      const val = node.value.trim();
 
-      // for ## H2
-      if (node.depth === 2) {
-        slides.push(current);
-        current = {
-          id: globalThis.crypto.randomUUID(),
-          type: 'content',
-          title: text,
-          content: [],
-        };
+      if (val === '<!-- notes -->') {
+        inNotes = true;
         continue;
       }
 
-      // for # H1
+      if (val === '<!-- /notes -->') {
+        inNotes = false;
+        continue;
+      }
+
+      const layoutMatch = val.match(/^<!--\s*layout:\s*(\w+)\s*-->$/);
+      if (layoutMatch) {
+        current.layoutOverride = layoutMatch[1];
+        continue;
+      }
+    }
+
+    // collect text into notes field while inside a notes block
+    if (inNotes) {
+      const text = extractText(node).trim();
+      if (text) {
+        current.notes = current.notes ? `${current.notes}\n${text}` : text;
+      }
+      continue;
+    }
+
+    // headings control slide boundaries and titles
+    if (node.type === 'heading') {
+      const text = headingText(node);
+
+      // ## for H2
+      if (node.depth === 2) {
+        slides.push(current);
+        current = freshSlide(text);
+        continue;
+      }
+
+      // # for H1
       if (node.depth === 1) {
         current.title = text;
         continue;
@@ -62,6 +100,5 @@ export function splitSlides(tree: Root): Slide[] {
     current.content.push(toNode(node));
   }
   slides.push(current);
-
   return slides;
 }

--- a/packages/parser/tests/detect-layout.test.ts
+++ b/packages/parser/tests/detect-layout.test.ts
@@ -30,8 +30,31 @@ describe('detectLayout', () => {
       type: 'content',
       content: [{ type: 'text' }],
     };
-
     const result = detectLayout(slide);
     expect(result.type).toBe('content');
+  });
+
+  it('should follow layoutOverride even when content would auto-detect differently', () => {
+    const slide: Slide = {
+      id: '4',
+      type: 'content',
+      title: 'My Slide',
+      content: [{ type: 'list' }],
+      layoutOverride: 'content',
+    };
+    const result = detectLayout(slide);
+    expect(result.type).toBe('content');
+  });
+
+  it('should set type from layoutOverride on a title-only slide', () => {
+    const slide: Slide = {
+      id: '5',
+      type: 'content',
+      title: 'Override Me',
+      content: [],
+      layoutOverride: 'bullets',
+    };
+    const result = detectLayout(slide);
+    expect(result.type).toBe('bullets');
   });
 });

--- a/packages/parser/tests/parse.test.ts
+++ b/packages/parser/tests/parse.test.ts
@@ -3,59 +3,104 @@ import { parse } from '../src/parse.js';
 
 describe('parse', () => {
   it('parse a simple paragraph to slide', () => {
-    const result = parse('hello world');
-    expect(result).toHaveLength(1);
-    expect(result[0].content[0].type).toBe('paragraph');
+    const { slides } = parse('hello world');
+    expect(slides).toHaveLength(1);
+    expect(slides[0].content[0].type).toBe('paragraph');
   });
 
-  it('---  : splits into two slides', () => {
-    const result = parse(`
+  it('--- : splits into two slides', () => {
+    const { slides } = parse(`
 first slide
 ---
 second slide
-        `);
-
-    expect(result).toHaveLength(2);
+    `);
+    expect(slides).toHaveLength(2);
   });
 
   it('# sets the title on the slide', () => {
-    const result = parse(`
+    const { slides } = parse(`
 # My Presentation
 
 some content
-        `);
-
-    expect(result[0].title).toBe('My Presentation');
+    `);
+    expect(slides[0].title).toBe('My Presentation');
   });
 
   it('## starts a new slide with that title', () => {
-    const result = parse(`
+    const { slides } = parse(`
 ## Intro
 
 some content
-        `);
-
-    const slide = result.find((s) => s.title === 'Intro');
+    `);
+    const slide = slides.find((s) => s.title === 'Intro');
     expect(slide).toBeDefined();
     expect(slide!.content[0].type).toBe('paragraph');
   });
 
   it('bullet list is present then slide detected as bullets layout', () => {
-    const result = parse(`
+    const { slides } = parse(`
 ## Features
 
 - fast
 - simple
 - reliable
-        `);
-
-    const slide = result.find((s) => s.title === 'Features');
+    `);
+    const slide = slides.find((s) => s.title === 'Features');
     expect(slide).toBeDefined();
     expect(slide!.type).toBe('bullets');
   });
 
   it('title is present then slide detected as title layout', () => {
-    const result = parse('# My Presentation');
-    expect(result[0].type).toBe('title');
+    const { slides } = parse('# My Presentation');
+    expect(slides[0].type).toBe('title');
+  });
+
+  it('extracts frontmatter meta and does not show in slides', () => {
+    const { meta, slides } = parse(`---
+title: My Deck
+theme: dark
+---
+
+# First Slide
+    `);
+    expect(meta.title).toBe('My Deck');
+    expect(meta.theme).toBe('dark');
+    expect(slides[0].content).toHaveLength(0);
+  });
+
+  it('returns empty meta when no frontmatter is present', () => {
+    const { meta } = parse('# No Frontmatter');
+    expect(meta).toEqual({});
+  });
+
+  it('collects notes into the notes field and removes them from content', () => {
+    const { slides } = parse(`
+## My Slide
+
+- Point one
+
+<!-- notes -->
+Hi I am Rushik who works on projects
+<!-- /notes -->
+    `);
+    const slide = slides.find((s) => s.title === 'My Slide');
+    expect(slide).toBeDefined();
+    expect(slide!.notes).toBe('Hi I am Rushik who works on projects');
+    const hasHtmlNode = slide!.content.some((n) => n.type === 'html');
+    expect(hasHtmlNode).toBe(false);
+  });
+
+  it('respects layout override comment and skips auto-detection', () => {
+    const { slides } = parse(`
+## My Slide
+
+<!-- layout: content -->
+
+- Point one
+- Point two
+    `);
+    const slide = slides.find((s) => s.title === 'My Slide');
+    expect(slide).toBeDefined();
+    expect(slide!.type).toBe('content');
   });
 });

--- a/packages/parser/tests/split.test.ts
+++ b/packages/parser/tests/split.test.ts
@@ -57,6 +57,22 @@ describe('splitSlides', () => {
     expect(result[0].title).toBe('My Presentation');
   });
 
+  it('collects notes between :<!-- notes --> and <!-- /notes -->', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        { type: 'html', value: '<!-- notes -->' },
+        { type: 'paragraph', children: [{ type: 'text', value: 'speaker note' }] },
+        { type: 'html', value: '<!-- /notes -->' },
+        { type: 'paragraph', children: [{ type: 'text', value: 'visible' }] },
+      ],
+    };
+    const result = splitSlides(tree);
+    expect(result).toHaveLength(1);
+    expect(result[0].notes).toBe('speaker note');
+    expect(result[0].content[0].type).toBe('paragraph');
+  });
+
   it('every slide should have its own id', () => {
     const tree: Root = {
       type: 'root',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -12,9 +12,10 @@ export interface Slide {
   title?: string;
   content: SlideNode[];
   notes?: string;
+  layoutOverride?: string;
 }
 
 export interface SlideDeck {
-  meta?: Record<string, unknown>;
+  meta: Record<string, unknown>;
   slides: Slide[];
 }


### PR DESCRIPTION
## Description

The parser package now has three new features that make it easier and more flexible to write slides. The parser package has changes in `parse.ts`, `split.ts`, and `detect-layout.ts`, and the shared package has a type update.

**FR-17 — Frontmatter Extraction (`parse.ts`)**
Before sending the Markdown to `remark-parse`, `parse.ts` now calls `parseFrontmatter` from the shared package. This takes the YAML block at the top of the file, which is called `---`, and turns it into a `meta` object. It then sends only the clean content body to the AST pipeline. The return type of `parse()` changes from `Slide[]` to `SlideDeck`, which has both `meta` and `slides`.

**FR-16 — Speaker Notes Extraction (`split.ts`)**
Now, when you walk the AST, `splitSlides` looks for HTML comment nodes that say `<!-- notes -->` and `<!-- /notes -->`. When it gets to a notes block, it stops adding content to the slide's `content` array. Instead, it uses `extractText`, a helper that pulls plain text out of any node, to put the text into a separate `notes` field. The comment nodes are thrown away and never reach the renderer.

**FR-06 — Manual Layout Override (`split.ts` + `detect-layout.ts`)**
`splitSlides` also looks for `<!`-- layout: x --> comments. It saves the value in a "layoutOverride" field on the current slide and gets rid of the comment from content when it finds one. `detectLayout` first looks for `layoutOverride`. If it finds one, it sets the slide `type` directly from that value and doesn't do any auto-detection.

## Proposed Solution
All three features add to the existing AST  in `splitSlides` by taking care of `html` type nodes that were previously ignored. The logic is additive, so normal slides with no comments or frontmatter are not affected at all.

Functions modified or added:

- `parseFrontmatter()` — called in `parse.ts` before remark parsing (FR-17)
- `extractText()` — new helper in `split.ts` that recursively extracts plain text from any AST node (FR-16)
- `freshSlide()` — refactored to accept an optional title to remove repetition at H1 and H2 (markdown headings)
- `headingText()` — new helper in `split.ts` that extracts text from a heading node, shared by both H1 and H2.
- `splitSlides()` — extended with html node handling for notes and layout override (FR-16, FR-06)
- `detectLayout()` — extended with layoutOverride priority check before auto-detection (FR-06)

## Closes

Closes Issue #9 , #10 , #11 

## Output Format (if applicable)

`parse()` now returns a `SlideDeck` JSON object instead of a flat `Slide[]`:

```
{
  meta: { title, theme, split, ... },  (FR-17)
  slides: [
    {
      id, type, title, content,
      notes: "presenter-only text",   (FR-16)
      layoutOverride: "bullets"        (FR-06)
    }
  ]
}
```


