### PR TITLE
Feat/markdown parser

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
       "dependencies": {
         "@mindfiredigital/mdslide-shared": "workspace:*",
         "gray-matter": "^4.0.3",
+        "mdast-util-to-string": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "unified": "^11.0.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@mindfiredigital/mdslide-shared": "workspace:*",
     "gray-matter": "^4.0.3",
+    "mdast-util-to-string": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.5"

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -1,0 +1,1 @@
+export const MAX_SLIDE_SCORE = 8;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,1 @@
+export * from './parser/markdown_parser.js';

--- a/packages/core/src/interfaces/index.ts
+++ b/packages/core/src/interfaces/index.ts
@@ -1,0 +1,1 @@
+export * from './markdown-parser/index.js';

--- a/packages/core/src/interfaces/markdown-parser/index.ts
+++ b/packages/core/src/interfaces/markdown-parser/index.ts
@@ -1,0 +1,11 @@
+import { Root, RootContent } from 'mdast';
+
+export interface RawSlideBlock {
+  id: string;
+  nodes: RootContent[];
+}
+
+export interface ParseMarkdownResult {
+  root: Root;
+  slides: RawSlideBlock[];
+}

--- a/packages/core/src/parser/lexer.ts
+++ b/packages/core/src/parser/lexer.ts
@@ -1,0 +1,33 @@
+import type { RootContent } from 'mdast';
+
+export function isThematicBreak(node: RootContent): boolean {
+  return node.type === 'thematicBreak';
+}
+
+export function isHeading(node: RootContent): boolean {
+  return node.type === 'heading';
+}
+
+export function isHTML(node: RootContent): boolean {
+  return node.type === 'html';
+}
+
+export function isList(node: RootContent): boolean {
+  return node.type === 'list';
+}
+
+export function isBlockquote(node: RootContent): boolean {
+  return node.type === 'blockquote';
+}
+
+export function isCode(node: RootContent): boolean {
+  return node.type === 'code';
+}
+
+export function isTable(node: RootContent): boolean {
+  return node.type === 'table';
+}
+
+export function isImage(node: RootContent): boolean {
+  return node.type === 'image';
+}

--- a/packages/core/src/parser/markdown_parser.ts
+++ b/packages/core/src/parser/markdown_parser.ts
@@ -1,0 +1,129 @@
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import type { Root, RootContent } from 'mdast';
+import type { RawSlideBlock, ParseMarkdownResult } from '../interfaces/index.js';
+import { isThematicBreak, isHeading } from './lexer.js';
+import { MAX_SLIDE_SCORE } from '../constants/index.js';
+import { getNodeWeight } from '../utils/index.js';
+
+export function parseMarkdown(markdown: string): ParseMarkdownResult {
+  try {
+    const root = unified().use(remarkParse).use(remarkGfm).parse(markdown) as Root;
+
+    if (!root.children?.length) {
+      return {
+        root,
+        slides: [],
+      };
+    }
+
+    const nodes = root.children;
+    const hasThematicBreak = nodes.some(isThematicBreak);
+    const hasH2 = nodes.some((node) => isHeading(node) && 'depth' in node && node.depth === 2);
+
+    const slides: RawSlideBlock[] = [];
+
+    // PHASE 1: Thematic_breaks || Heading 2 (--- or ## Heading 2)
+    if (hasThematicBreak || hasH2) {
+      let currentNodes: RootContent[] = [];
+
+      const pushSlide = () => {
+        if (currentNodes.length > 0) {
+          slides.push({
+            id: globalThis.crypto.randomUUID(),
+            nodes: currentNodes,
+          });
+          currentNodes = [];
+        }
+      };
+
+      for (const node of nodes) {
+        if (isThematicBreak(node)) {
+          pushSlide();
+          continue;
+        }
+
+        if (isHeading(node) && 'depth' in node && node.depth === 2 && currentNodes.length > 0) {
+          pushSlide();
+        }
+
+        currentNodes.push(node);
+      }
+
+      pushSlide();
+    }
+
+    // PHASE 2: Other structural headings (# H1 or ### H3)
+    else {
+      const hasAnyHeading = nodes.some(
+        (node: RootContent) => isHeading(node) && [1, 2, 3].includes((node as any).depth)
+      );
+      if (hasAnyHeading) {
+        let currentNodes: RootContent[] = [];
+
+        const pushSlide = () => {
+          if (currentNodes.length > 0) {
+            slides.push({
+              id: globalThis.crypto.randomUUID(),
+              nodes: currentNodes,
+            });
+            currentNodes = [];
+          }
+        };
+
+        for (const node of nodes) {
+          const isMajorHeading = isHeading(node) && [1, 2, 3].includes((node as any).depth);
+
+          if (isMajorHeading && currentNodes.length > 0) {
+            pushSlide();
+          }
+
+          currentNodes.push(node);
+        }
+
+        pushSlide();
+      }
+
+      // PHASE 3: Size-based score chunking (Fallback for flat content documents)
+      else {
+        let currentNodes: RootContent[] = [];
+        let currentScore = 0;
+
+        const pushSlide = () => {
+          if (currentNodes.length > 0) {
+            slides.push({
+              id: globalThis.crypto.randomUUID(),
+              nodes: currentNodes,
+            });
+
+            currentNodes = [];
+            currentScore = 0;
+          }
+        };
+
+        for (const node of nodes) {
+          const weight = getNodeWeight(node);
+
+          if (currentScore + weight > MAX_SLIDE_SCORE && currentNodes.length > 0) {
+            pushSlide();
+          }
+
+          currentNodes.push(node);
+          currentScore += weight;
+        }
+
+        pushSlide();
+      }
+    }
+
+    return {
+      root,
+      slides,
+    };
+  } catch (err) {
+    throw new Error(
+      `Failed to parse markdown AST: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}

--- a/packages/core/src/utils/getNodeWeight.ts
+++ b/packages/core/src/utils/getNodeWeight.ts
@@ -1,0 +1,26 @@
+import { RootContent } from 'mdast';
+import { isHeading } from '../parser/lexer.js';
+import { toString } from 'mdast-util-to-string';
+
+function getNodeWeight(node: RootContent): number {
+  if (isHeading(node)) return 2;
+
+  switch (node.type) {
+    case 'paragraph':
+      return Math.max(1, Math.ceil(toString(node).split(/\s+/).length / 20));
+
+    case 'list':
+      return node.children?.length ?? 0;
+
+    case 'table':
+      return 4;
+
+    case 'code':
+      return Math.max(1, Math.ceil((node.value || '').split('\n').length / 5));
+
+    default:
+      return 1;
+  }
+}
+
+export { getNodeWeight };

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './getNodeWeight.js';


### PR DESCRIPTION
Add markdown parser 
- added 3 type of condition for breaking the slide content's
    - 1st format (2nd level heading and thematic breaks)
    - 2nd format (is there any type of heading is exist)
    - 3rd format (calculating node bases weight and in one slide fix size of weight should be there 

closes #31 