### PR TITLE
Feat/pptx export

### DIFF
--- a/packages/cli/src/assets/icons/index.ts
+++ b/packages/cli/src/assets/icons/index.ts
@@ -1,4 +1,8 @@
 export const icons = {
   cross: '✖',
   rightArrow: '→',
+  warning: '⚠',
+  info: '●',
+  succcess: '✔',
+  dim: '·',
 };

--- a/packages/cli/src/assets/icons/index.ts
+++ b/packages/cli/src/assets/icons/index.ts
@@ -5,4 +5,5 @@ export const icons = {
   info: '●',
   succcess: '✔',
   dim: '·',
+  navigateArrow: '❯',
 };

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -32,28 +32,56 @@ try {
 const cli = cac('mdslide');
 
 cli.version(version);
+cli.usage('<input> [options]');
 cli.help();
+
+cli.example('  mdslide slides.md                     # Interactive mode (runs wizard)');
+cli.example('  mdslide slides.md -i                  # Explicit interactive mode');
+cli.example('  mdslide slides.md -t dark --open      # Manual flags mode (bypasses wizard)');
 
 cli
   .command('compile <input>', 'Compile a Markdown presentation to HTML, PDF, or PPTX')
   .option('-t, --theme <theme>', 'Theme: light | dark | notion | terminal | gradient')
   .option('-o, --output <file>', 'Output file path  (default: output.<format>)')
   .option('-f, --format <format>', 'Format: html | pdf | pptx  (auto-detected from -o extension)')
+  .option('-i, --interactive', 'Run compile interactively')
   .option('--open', 'Open the output file after compile')
   .option('--strict', 'Exit with error on warnings')
   .option('--verbose', 'Verbose log output')
   .option('--silent', 'Suppress all output')
   .example('  mdslide compile slides.md')
+  .example('  mdslide compile slides.md -i')
   .example('  mdslide compile slides.md -t dark -o dist/deck.html')
   .example('  mdslide compile slides.md -f pptx -o deck.pptx')
   .action(async (input: string, opts: any) => {
+    const logLevel = opts.verbose ? 'verbose' : opts.silent ? 'silent' : 'info';
+    if (opts.interactive) {
+      const answers = await runInteractivePrompt(input);
+      if (answers.watch) {
+        await watchCommand(input, {
+          theme: answers.theme,
+          open: answers.open,
+          logLevel,
+        });
+      } else {
+        await compileCommand(input, {
+          theme: answers.theme,
+          output: answers.output,
+          format: answers.format as any,
+          open: answers.open,
+          logLevel,
+        });
+      }
+      return;
+    }
+
     await compileCommand(input, {
       theme: opts.theme,
       output: opts.output,
       format: opts.format,
       open: opts.open ?? false,
       strict: opts.strict ?? false,
-      logLevel: opts.verbose ? 'verbose' : opts.silent ? 'silent' : 'info',
+      logLevel,
     });
   });
 
@@ -105,23 +133,54 @@ cli
     });
   });
 
+// interactive
+cli
+  .command('interactive <input>', 'Compile a presentation using the interactive wizard')
+  .option('--verbose', 'Verbose log output')
+  .option('--silent', 'Suppress all output')
+  .example('  mdslide interactive slides.md')
+  .action(async (input: string, opts: any) => {
+    const logLevel = opts.verbose ? 'verbose' : opts.silent ? 'silent' : 'info';
+    const answers = await runInteractivePrompt(input);
+
+    if (answers.watch) {
+      await watchCommand(input, {
+        theme: answers.theme,
+        open: answers.open,
+        logLevel,
+      });
+    } else {
+      await compileCommand(input, {
+        theme: answers.theme,
+        output: answers.output,
+        format: answers.format as any,
+        open: answers.open,
+        logLevel,
+      });
+    }
+  });
+
 // default command
 cli
-  .command('<input>', 'Compile a presentation (interactive if no flags given)')
+  .command('<input>', 'Compile a presentation (runs interactively or with manual flags)')
   .option('-t, --theme <theme>', 'Theme override')
   .option('-o, --output <file>', 'Output file path')
   .option('-f, --format <format>', 'Output format: html | pdf | pptx')
+  .option('-i, --interactive', 'Run interactively')
   .option('-w, --watch', 'Start live-reload watch server')
   .option('-p, --port <port>', 'Watch server port  (default: 3500)')
   .option('--open', 'Open output after compile')
   .option('--verbose', 'Verbose log output')
   .option('--silent', 'Suppress all output')
+  .example('  mdslide slides.md                     # Interactive mode (runs wizard)')
+  .example('  mdslide slides.md -i                  # Explicit interactive mode')
+  .example('  mdslide slides.md -t dark --open      # Manual flags mode (bypasses wizard)')
   .action(async (input: string, opts: any) => {
     const logLevel = opts.verbose ? 'verbose' : opts.silent ? 'silent' : 'info';
     const hasFlags = opts.theme || opts.output || opts.format || opts.watch || opts.open;
 
     // interactive prompt
-    if (!hasFlags) {
+    if (opts.interactive || !hasFlags) {
       const answers = await runInteractivePrompt(input);
 
       if (answers.watch) {
@@ -163,6 +222,10 @@ cli
 
 // parse all the commands
 try {
+  if (process.argv.length <= 2) {
+    cli.outputHelp();
+    process.exit(0);
+  }
   cli.parse(process.argv);
 } catch (err: any) {
   const log = new Logger('info');

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+import { createRequire } from 'module';
+import { compileCommand } from './commands/compile.js';
+import { watchCommand } from './commands/watch.js';
+import { initCommand } from './commands/init.js';
+import { validateCommand } from './commands/validate.js';
+import { runInteractivePrompt } from './interactiveCommands/index.js';
+import { Logger } from './logger/index.js';
+import { icons } from './assets/index.js';
+import { ICONS } from './utils/index.js';
+import { COLORS, STYLES } from './constants/terminalEscapeCode.js';
+
+const require = createRequire(import.meta.url);
+
+let version = '0.0.0';
+try {
+  const pkg = require('../package.json');
+  version = pkg.version ?? '0.0.0';
+} catch {}
+
+let cac: any;
+try {
+  cac = (await import('cac')).default;
+} catch {
+  console.error(
+    `\n  ${icons.cross}  Missing dependency: cac\n  ${icons.rightArrow} Run: npm install cac\n`
+  );
+  process.exit(1);
+}
+
+const cli = cac('mdslide');
+
+cli.version(version);
+cli.help();
+
+cli
+  .command('compile <input>', 'Compile a Markdown presentation to HTML, PDF, or PPTX')
+  .option('-t, --theme <theme>', 'Theme: light | dark | notion | terminal | gradient')
+  .option('-o, --output <file>', 'Output file path  (default: output.<format>)')
+  .option('-f, --format <format>', 'Format: html | pdf | pptx  (auto-detected from -o extension)')
+  .option('--open', 'Open the output file after compile')
+  .option('--strict', 'Exit with error on warnings')
+  .option('--verbose', 'Verbose log output')
+  .option('--silent', 'Suppress all output')
+  .example('  mdslide compile slides.md')
+  .example('  mdslide compile slides.md -t dark -o dist/deck.html')
+  .example('  mdslide compile slides.md -f pptx -o deck.pptx')
+  .action(async (input: string, opts: any) => {
+    await compileCommand(input, {
+      theme: opts.theme,
+      output: opts.output,
+      format: opts.format,
+      open: opts.open ?? false,
+      strict: opts.strict ?? false,
+      logLevel: opts.verbose ? 'verbose' : opts.silent ? 'silent' : 'info',
+    });
+  });
+
+// watch
+cli
+  .command('watch <input>', 'Start a live-reload preview server')
+  .option('-t, --theme <theme>', 'Theme override')
+  .option('-p, --port <port>', 'Port for the dev server  (default: 3500)', { default: 3500 })
+  .option('--open', 'Open the browser automatically')
+  .option('--verbose', 'Verbose log output')
+  .option('--silent', 'Suppress all output')
+  .example('  mdslide watch slides.md')
+  .example('  mdslide watch slides.md --port 4000 --open')
+  .action(async (input: string, opts: any) => {
+    await watchCommand(input, {
+      theme: opts.theme,
+      port: Number(opts.port) || 3500,
+      open: opts.open ?? false,
+      logLevel: opts.verbose ? 'verbose' : opts.silent ? 'silent' : 'info',
+    });
+  });
+
+// init
+cli
+  .command('init', 'Scaffold a new presentation in the current directory')
+  .option('--force', 'Overwrite existing files')
+  .option('--silent', 'Suppress all output')
+  .example('  mdslide init')
+  .example('  mdslide init --force')
+  .action(async (opts: any) => {
+    await initCommand({
+      force: opts.force ?? false,
+      logLevel: opts.silent ? 'silent' : 'info',
+    });
+  });
+
+// validate
+cli
+  .command('validate <input>', 'Lint a Markdown presentation for issues')
+  .option('--strict', 'Exit with error on warnings')
+  .option('--verbose', 'Verbose log output')
+  .option('--silent', 'Suppress all output')
+  .example('  mdslide validate slides.md')
+  .example('  mdslide validate slides.md --strict')
+  .action(async (input: string, opts: any) => {
+    await validateCommand(input, {
+      strict: opts.strict ?? false,
+      logLevel: opts.verbose ? 'verbose' : opts.silent ? 'silent' : 'info',
+    });
+  });
+
+// default command
+cli
+  .command('<input>', 'Compile a presentation (interactive if no flags given)')
+  .option('-t, --theme <theme>', 'Theme override')
+  .option('-o, --output <file>', 'Output file path')
+  .option('-f, --format <format>', 'Output format: html | pdf | pptx')
+  .option('-w, --watch', 'Start live-reload watch server')
+  .option('-p, --port <port>', 'Watch server port  (default: 3500)')
+  .option('--open', 'Open output after compile')
+  .option('--verbose', 'Verbose log output')
+  .option('--silent', 'Suppress all output')
+  .action(async (input: string, opts: any) => {
+    const logLevel = opts.verbose ? 'verbose' : opts.silent ? 'silent' : 'info';
+    const hasFlags = opts.theme || opts.output || opts.format || opts.watch || opts.open;
+
+    // interactive prompt
+    if (!hasFlags) {
+      const answers = await runInteractivePrompt(input);
+
+      if (answers.watch) {
+        await watchCommand(input, {
+          theme: answers.theme,
+          open: answers.open,
+          logLevel,
+        });
+      } else {
+        await compileCommand(input, {
+          theme: answers.theme,
+          output: answers.output,
+          format: answers.format as any,
+          open: answers.open,
+          logLevel,
+        });
+      }
+      return;
+    }
+
+    // flag's present
+    if (opts.watch) {
+      await watchCommand(input, {
+        theme: opts.theme,
+        port: Number(opts.port) || 3500,
+        open: opts.open ?? false,
+        logLevel,
+      });
+    } else {
+      await compileCommand(input, {
+        theme: opts.theme,
+        output: opts.output,
+        format: opts.format,
+        open: opts.open ?? false,
+        logLevel,
+      });
+    }
+  });
+
+// parse all the commands
+try {
+  cli.parse(process.argv);
+} catch (err: any) {
+  const log = new Logger('info');
+  log.raw('');
+  log.raw(`  ${ICONS.error}  ${err.message}`);
+  log.raw(`     ${ICONS.step} ${COLORS.cyan}Run \`mdslide --help\` to see usage.${STYLES.reset}`);
+  log.raw('');
+  process.exit(1);
+}

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -7,6 +7,7 @@ import type { CompileOptions, OutputFormat } from '../types/index.js';
 import { RELOAD_SCRIPT } from '../script/reloadScript.js';
 import { COMPILE_CONFIG, COMPILE_MESSAGES } from '../constants/index.js';
 import { compileToPdf } from '../exports/pdfExports.js';
+import { compileToScreenshotPptx, compileToEditablePptx } from '../exports/pptxExports.js';
 
 // format detection (pdf, pptx, html)
 function detectFormat(
@@ -81,9 +82,14 @@ export async function compileCommand(inputFile: string, opts: CompileOptions): P
   let html: string;
   let slideCount: number;
   let warnings: string[];
+  let deck: any;
 
   try {
-    ({ html, slideCount, warnings } = await runCompile(absInput, opts, log));
+    const compileResult = await runCompile(absInput, opts, log);
+    html = compileResult.html;
+    slideCount = compileResult.slideCount;
+    warnings = compileResult.warnings;
+    deck = { slides: compileResult.slides, meta: compileResult.meta };
   } catch (err) {
     spinner.fail();
     log.error(err);
@@ -100,6 +106,21 @@ export async function compileCommand(inputFile: string, opts: CompileOptions): P
         chromePath: process.env['CHROME_PATH'],
         timeoutMs: opts.pdfTimeoutMs ?? 30_000,
       });
+    } else if (format === 'pptx') {
+      const pptxMode = opts.pptxMode ?? 'screenshot';
+      spinner.update(`Building PPTX (${pptxMode} mode)...`);
+      fs.mkdirSync(path.dirname(absOutput), { recursive: true });
+      if (pptxMode === 'editable') {
+        await compileToEditablePptx(deck, absOutput, {
+          theme: opts.theme,
+          baseDir: path.dirname(path.resolve(inputFile)),
+        });
+      } else {
+        await compileToScreenshotPptx(html, slideCount, absOutput, {
+          theme: opts.theme,
+          baseDir: path.dirname(path.resolve(inputFile)),
+        });
+      }
     }
   } catch (err) {
     spinner.fail();

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -1,0 +1,153 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import { Logger } from '../logger/index.js';
+import { Spinner } from '../ui/spinner.js';
+import {
+  InputNotFoundError,
+  InvalidFormatError,
+  ChromeNotFoundError,
+  CompileError,
+} from '../middleware/errors.js';
+import type { CompileOptions, OutputFormat } from '../types/index.js';
+import { RELOAD_SCRIPT } from '../script/reloadScript.js';
+import { COMPILE_CONFIG, COMPILE_MESSAGES } from '../constants/index.js';
+
+// fixme: Chrome binary detection , current for testin purpost i use only chrome linux paths , in future add all hardcore path and add --browserpath "path"
+function findChromeBinary(): string {
+  // Used systemic candidate collection constant here
+  for (const bin of COMPILE_CONFIG.CHROME_CANDIDATES) {
+    try {
+      execSync(`which ${bin} > /dev/null 2>&1`);
+      return bin;
+    } catch {
+      // not found
+    }
+  }
+  throw new ChromeNotFoundError();
+}
+
+// format detection (pdf, pptx, html)
+function detectFormat(
+  outputFile: string | undefined,
+  formatFlag: string | undefined
+): OutputFormat {
+  if (formatFlag) {
+    const f = formatFlag.toLowerCase() as OutputFormat;
+    if (!COMPILE_CONFIG.SUPPORTED_FORMATS.includes(f)) throw new InvalidFormatError(formatFlag);
+    return f;
+  }
+  if (outputFile) {
+    const ext = path.extname(outputFile).toLowerCase();
+    if (ext === '.pdf') return 'pdf';
+    if (ext === '.pptx') return 'pptx';
+  }
+  return COMPILE_CONFIG.DEFAULT_FORMAT;
+}
+
+// Core compile
+export async function runCompile(
+  inputFile: string,
+  opts: CompileOptions,
+  log: Logger,
+  options?: { injectReload?: boolean }
+): Promise<{ html: string; slideCount: number; warnings: string[] }> {
+  if (!fs.existsSync(inputFile)) throw new InputNotFoundError(inputFile);
+
+  let Compiler: any;
+  try {
+    const core = await import('@mindfiredigital/mdslide-core');
+    Compiler = core.Compiler;
+  } catch {
+    throw new CompileError(COMPILE_MESSAGES.CORE_NOT_FOUND, {});
+  }
+
+  const markdown = fs.readFileSync(inputFile, 'utf8');
+  let result: any;
+
+  try {
+    const compiler = new Compiler();
+    result = compiler.compile(markdown, { theme: opts.theme });
+  } catch (err: any) {
+    throw new CompileError(err.message, { file: inputFile });
+  }
+
+  let html: string = result.html;
+  if (options?.injectReload) {
+    html = html.replace('</body>', `${RELOAD_SCRIPT}\n</body>`);
+  }
+
+  const slideCount = result.slides?.length ?? 0;
+  const warnings = result.warnings ?? [];
+
+  return { html, slideCount, warnings };
+}
+
+// Compiler the commands
+export async function compileCommand(inputFile: string, opts: CompileOptions): Promise<void> {
+  const log = new Logger(opts.logLevel ?? 'info');
+  const spinner = new Spinner(log);
+
+  const format = detectFormat(opts.output, opts.format);
+  const outputFile = opts.output ?? `output.${format}`;
+  const absInput = path.resolve(inputFile);
+  const absOutput = path.resolve(outputFile);
+
+  spinner.start(COMPILE_MESSAGES.SPINNER_START(path.basename(absInput), format));
+
+  let html: string;
+  let slideCount: number;
+  let warnings: string[];
+
+  try {
+    ({ html, slideCount, warnings } = await runCompile(absInput, opts, log));
+  } catch (err) {
+    spinner.fail();
+    log.error(err);
+    process.exit(1);
+  }
+
+  try {
+    if (format === 'html') {
+      fs.mkdirSync(path.dirname(absOutput), { recursive: true });
+      fs.writeFileSync(absOutput, html);
+    } else if (format === 'pdf') {
+      const tempPath = path.join(path.dirname(absOutput), `.mdslide-tmp-${Date.now()}.html`);
+      fs.writeFileSync(tempPath, html);
+
+      try {
+        const chrome = findChromeBinary();
+        spinner.update(COMPILE_MESSAGES.SPINNER_LAUNCHING_CHROME);
+        // Used unified binary invocation flags constant here
+        execSync(
+          `"${chrome}" ${COMPILE_CONFIG.CHROME_FLAGS} ` +
+            `--print-to-pdf="${absOutput}" "${tempPath}"`,
+          { stdio: 'ignore' }
+        );
+      } finally {
+        if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath);
+      }
+    }
+  } catch (err) {
+    spinner.fail();
+    log.error(err);
+    process.exit(1);
+  }
+
+  spinner.succeed(
+    COMPILE_MESSAGES.SUCCESS_SUMMARY(
+      path.relative(process.cwd(), absOutput),
+      slideCount,
+      warnings.length
+    )
+  );
+
+  if (warnings.length) {
+    for (const w of warnings) log.warn(w);
+  }
+
+  if (opts.open) {
+    const { default: open } = await import('open').catch(() => ({ default: null }));
+    if (open) open(absOutput).catch(() => {});
+  }
+}

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -1,31 +1,12 @@
 import fs from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
 import { Logger } from '../logger/index.js';
 import { Spinner } from '../ui/spinner.js';
-import {
-  InputNotFoundError,
-  InvalidFormatError,
-  ChromeNotFoundError,
-  CompileError,
-} from '../middleware/errors.js';
+import { InputNotFoundError, InvalidFormatError, CompileError } from '../middleware/errors.js';
 import type { CompileOptions, OutputFormat } from '../types/index.js';
 import { RELOAD_SCRIPT } from '../script/reloadScript.js';
 import { COMPILE_CONFIG, COMPILE_MESSAGES } from '../constants/index.js';
-
-// fixme: Chrome binary detection , current for testin purpost i use only chrome linux paths , in future add all hardcore path and add --browserpath "path"
-function findChromeBinary(): string {
-  // Used systemic candidate collection constant here
-  for (const bin of COMPILE_CONFIG.CHROME_CANDIDATES) {
-    try {
-      execSync(`which ${bin} > /dev/null 2>&1`);
-      return bin;
-    } catch {
-      // not found
-    }
-  }
-  throw new ChromeNotFoundError();
-}
+import { compileToPdf } from '../exports/pdfExports.js';
 
 // format detection (pdf, pptx, html)
 function detectFormat(
@@ -51,7 +32,7 @@ export async function runCompile(
   opts: CompileOptions,
   log: Logger,
   options?: { injectReload?: boolean }
-): Promise<{ html: string; slideCount: number; warnings: string[] }> {
+): Promise<{ html: string; slideCount: number; warnings: string[]; slides: any[]; meta: any }> {
   if (!fs.existsSync(inputFile)) throw new InputNotFoundError(inputFile);
 
   let Compiler: any;
@@ -77,10 +58,12 @@ export async function runCompile(
     html = html.replace('</body>', `${RELOAD_SCRIPT}\n</body>`);
   }
 
+  const slides = result.slides ?? [];
+  const meta = result.meta ?? {};
   const slideCount = result.slides?.length ?? 0;
   const warnings = result.warnings ?? [];
 
-  return { html, slideCount, warnings };
+  return { html, meta, slides, slideCount, warnings };
 }
 
 // Compiler the commands
@@ -112,21 +95,11 @@ export async function compileCommand(inputFile: string, opts: CompileOptions): P
       fs.mkdirSync(path.dirname(absOutput), { recursive: true });
       fs.writeFileSync(absOutput, html);
     } else if (format === 'pdf') {
-      const tempPath = path.join(path.dirname(absOutput), `.mdslide-tmp-${Date.now()}.html`);
-      fs.writeFileSync(tempPath, html);
-
-      try {
-        const chrome = findChromeBinary();
-        spinner.update(COMPILE_MESSAGES.SPINNER_LAUNCHING_CHROME);
-        // Used unified binary invocation flags constant here
-        execSync(
-          `"${chrome}" ${COMPILE_CONFIG.CHROME_FLAGS} ` +
-            `--print-to-pdf="${absOutput}" "${tempPath}"`,
-          { stdio: 'ignore' }
-        );
-      } finally {
-        if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath);
-      }
+      spinner.update('Launching Chrome for PDF export...');
+      await compileToPdf(html, absOutput, {
+        chromePath: process.env['CHROME_PATH'],
+        timeoutMs: opts.pdfTimeoutMs ?? 30_000,
+      });
     }
   } catch (err) {
     spinner.fail();

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import path from 'path';
+import { Logger } from '../logger/index.js';
+import type { InitOptions } from '../types/index.js';
+import { SAMPLE_SLIDES } from '../constants/sampleSlide.js';
+import { SAMPLE_CONFIG } from '../constants/sampleConfig.js';
+import { DEV_COMMANDS, FILE_NAME, INIT_MESSAGES } from '../constants/logs/initCommandLogs.js';
+
+export async function initCommand(opts: InitOptions): Promise<void> {
+  const log = new Logger(opts.logLevel ?? 'info');
+  const cwd = process.cwd();
+  const slidesPath = path.join(cwd, FILE_NAME.SAMPLE_FILE_NAME);
+  const configPath = path.join(cwd, FILE_NAME.SAMPLE_CONFIG_FILE_NAME);
+
+  let created = 0;
+
+  if (!fs.existsSync(slidesPath) || opts.force) {
+    fs.writeFileSync(slidesPath, SAMPLE_SLIDES);
+    log.success(`${INIT_MESSAGES.SLIDES_CREATED}`);
+    created++;
+  } else {
+    log.warn(`${INIT_MESSAGES.SLIDES_EXISTS}`);
+  }
+
+  if (!fs.existsSync(configPath) || opts.force) {
+    fs.writeFileSync(configPath, SAMPLE_CONFIG);
+    log.success(`${INIT_MESSAGES.CONFIG_CREATED}`);
+    created++;
+  } else {
+    log.warn(`${INIT_MESSAGES.CONFIG_EXISTS}`);
+  }
+
+  const pkgPath = path.join(cwd, FILE_NAME.PACKAGE_NAME);
+  if (fs.existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+      if (!pkg.scripts?.dev) {
+        pkg.scripts = {
+          ...pkg.scripts,
+          dev: DEV_COMMANDS.DEV,
+          build: DEV_COMMANDS.BUILD,
+        };
+        fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+        log.success(`${INIT_MESSAGES.SCRIPTS_ADDED}`);
+      }
+    } catch {}
+  }
+
+  if (created > 0) {
+    log.raw('');
+    log.step(INIT_MESSAGES.NEXT_STEPS);
+    log.raw('');
+  }
+}

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -1,0 +1,114 @@
+import fs from 'fs';
+import path from 'path';
+import { Logger } from '../logger/index.js';
+import { InputNotFoundError } from '../middleware/errors.js';
+import type { ValidateOptions, ValidationIssue } from '../types/index.js';
+import { COLORS, STYLES, VALIDATION_MESSAGES, VALIDATION_RULES } from '../constants/index.js';
+import { ICONS } from '../utils/index.js';
+
+// Rules for the validate slides
+function validateSlides(markdown: string): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const slides = markdown.split(/\n---\n/);
+
+  if (slides.length === 1) {
+    issues.push({
+      type: 'warning',
+      ...VALIDATION_MESSAGES.NO_SEPARATORS,
+    });
+  }
+
+  for (let i = 0; i < slides.length; i++) {
+    const slide = slides[i]!;
+    const slideNo = i + 1;
+    const lines = slide.trim().split('\n');
+
+    if (slide.trim() === '') {
+      issues.push({
+        type: 'warning',
+        slide: slideNo,
+        ...VALIDATION_MESSAGES.EMPTY_SLIDE,
+      });
+    }
+
+    const hasHeading = lines.some((l) => /^#{1,6}\s/.test(l));
+    if (!hasHeading && slide.trim() !== '') {
+      issues.push({
+        type: 'warning',
+        slide: slideNo,
+        ...VALIDATION_MESSAGES.NO_HEADING,
+      });
+    }
+
+    // Used rule limit constant here
+    if (lines.length > VALIDATION_RULES.MAX_LINES_PER_SLIDE) {
+      issues.push({
+        type: 'warning',
+        slide: slideNo,
+        ...VALIDATION_MESSAGES.OVERFLOW(lines.length),
+      });
+    }
+
+    const codeFences = (slide.match(/^```/gm) ?? []).length;
+    if (codeFences % 2 !== 0) {
+      issues.push({
+        type: 'error',
+        slide: slideNo,
+        ...VALIDATION_MESSAGES.UNCLOSED_CODE_FENCE,
+      });
+    }
+  }
+
+  return issues;
+}
+
+// Validate orchastrator
+export async function validateCommand(inputFile: string, opts: ValidateOptions): Promise<void> {
+  const log = new Logger(opts.logLevel ?? 'info');
+  const absInput = path.resolve(inputFile);
+
+  if (!fs.existsSync(absInput)) {
+    log.error(new InputNotFoundError(absInput));
+    process.exit(1);
+  }
+
+  const markdown = fs.readFileSync(absInput, 'utf8');
+  const issues = validateSlides(markdown);
+
+  const errors = issues.filter((i) => i.type === 'error');
+  const warnings = issues.filter((i) => i.type === 'warning');
+
+  const slideCount = markdown.split(/\n---\n/).length;
+
+  log.raw('');
+
+  if (issues.length === 0) {
+    log.success(VALIDATION_MESSAGES.LOG_SUCCESS(path.basename(absInput), slideCount));
+    log.raw('');
+    return;
+  }
+
+  for (const issue of issues) {
+    const loc = issue.slide != null ? `  (slide ${issue.slide})` : '';
+    if (issue.type === 'error') {
+      log.raw(
+        `  ${ICONS.error}  ${STYLES.bold}${issue.message}${STYLES.reset}${COLORS.grey}${loc}${STYLES.reset}`
+      );
+    } else {
+      log.raw(`  ${ICONS.warn}  ${issue.message}${COLORS.grey}${loc}${STYLES.reset}`);
+    }
+    if (issue.hint) {
+      log.raw(`     ${ICONS.step} ${COLORS.cyan}${issue.hint}${STYLES.reset}`);
+    }
+  }
+
+  log.raw('');
+  log.raw(
+    `  ${COLORS.grey}${slideCount} slides - ${errors.length} error${errors.length !== 1 ? 's' : ''}, ${warnings.length} warning${warnings.length !== 1 ? 's' : ''}${STYLES.reset}`
+  );
+  log.raw('');
+
+  if (errors.length > 0 || (opts.strict && warnings.length > 0)) {
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import http from 'http';
 import path from 'path';
 import net from 'net';
+import chokidar from 'chokidar';
 import { Logger } from '../logger/index.js';
 import { Spinner } from '../ui/spinner.js';
 import { onShutdown } from '../middleware/signals.js';
@@ -62,7 +63,7 @@ export async function watchCommand(inputFile: string, opts: WatchOptions): Promi
   } catch (err) {
     spinner.fail(WATCH_MESSAGES.SPINNER_FAIL);
     log.error(err);
-    cachedHtml = buildErrorHtml(err);
+    process.exit(1);
   }
 
   const server = http.createServer((req, res) => {
@@ -108,6 +109,7 @@ export async function watchCommand(inputFile: string, opts: WatchOptions): Promi
   onShutdown(() => {
     server.close();
     clients.forEach((c) => c.end());
+    watcher.close().catch(() => {});
     log.raw('');
     log.step(WATCH_MESSAGES.SERVER_STOPPED);
   });
@@ -119,8 +121,15 @@ export async function watchCommand(inputFile: string, opts: WatchOptions): Promi
 
   let debounce: NodeJS.Timeout | null = null;
 
-  fs.watch(absInput, (eventType) => {
-    if (eventType !== 'change') return;
+  const watcher = chokidar.watch(absInput, {
+    ignoreInitial: true,
+  });
+
+  watcher.on('error', (err) => {
+    log.verbose(`Watcher encountered an error: ${(err as unknown as Error).message}`);
+  });
+
+  watcher.on('change', () => {
     if (debounce) clearTimeout(debounce);
     // Used debounce delay timing variable here
     debounce = setTimeout(async () => {
@@ -135,11 +144,11 @@ export async function watchCommand(inputFile: string, opts: WatchOptions): Promi
         cachedHtml = buildErrorHtml(err);
       }
 
-      for (const client of clients) {
+      for (let i = clients.length - 1; i >= 0; i--) {
         try {
-          client.write('data: reload\n\n');
+          clients[i].write('data: reload\n\n');
         } catch {
-          /* client disconnected */
+          clients.splice(i, 1);
         }
       }
     }, WATCH_CONFIG.DEBOUNCE_DELAY_MS);

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -1,0 +1,147 @@
+import fs from 'fs';
+import http from 'http';
+import path from 'path';
+import net from 'net';
+import { Logger } from '../logger/index.js';
+import { Spinner } from '../ui/spinner.js';
+import { onShutdown } from '../middleware/signals.js';
+import { InputNotFoundError, PortInUseError } from '../middleware/errors.js';
+import { runCompile } from './compile.js';
+import type { WatchOptions } from '../types/index.js';
+import { link } from '../utils/index.js';
+import { WATCH_CONFIG, WATCH_MESSAGES, ERROR_OVERLAY_TEMPLATE } from '../constants/index.js';
+
+function buildErrorHtml(err: unknown): string {
+  const e = err instanceof Error ? err : new Error(String(err));
+  const hint = (e as any).hint as string | undefined;
+  const escaped = e.message.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return ERROR_OVERLAY_TEMPLATE(escaped, hint);
+}
+
+function isPortFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const s = net.createServer();
+    s.once('error', () => resolve(false));
+    s.once('listening', () => s.close(() => resolve(true)));
+    s.listen(port);
+  });
+}
+
+async function findPort(preferred: number): Promise<number> {
+  for (let p = preferred; p < preferred + WATCH_CONFIG.PORT_SCAN_RANGE; p++) {
+    if (await isPortFree(p)) return p;
+  }
+  throw new PortInUseError(preferred);
+}
+
+export async function watchCommand(inputFile: string, opts: WatchOptions): Promise<void> {
+  const log = new Logger(opts.logLevel ?? 'info');
+  const absInput = path.resolve(inputFile);
+
+  if (!fs.existsSync(absInput)) {
+    log.error(new InputNotFoundError(absInput));
+    process.exit(1);
+  }
+
+  const preferredPort = opts.port ?? WATCH_CONFIG.PORT;
+  const port = await findPort(preferredPort).catch((err) => {
+    log.error(err);
+    process.exit(1);
+  });
+
+  let cachedHtml = '';
+  const clients: http.ServerResponse[] = [];
+
+  const spinner = new Spinner(log);
+  spinner.start(WATCH_MESSAGES.SPINNER_START(path.basename(absInput)));
+
+  try {
+    const { html } = await runCompile(absInput, opts, log, { injectReload: true });
+    cachedHtml = html;
+    spinner.succeed(WATCH_MESSAGES.SPINNER_READY);
+  } catch (err) {
+    spinner.fail(WATCH_MESSAGES.SPINNER_FAIL);
+    log.error(err);
+    cachedHtml = buildErrorHtml(err);
+  }
+
+  const server = http.createServer((req, res) => {
+    const url = req.url ?? '/';
+
+    // Used route config constant here
+    if (url === WATCH_CONFIG.LIVE_RELOAD_PATH) {
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      });
+      res.write(': connected\n\n');
+      clients.push(res);
+
+      // Used SSE timing variable here
+      const heartbeat = setInterval(
+        () => res.write(': ping\n\n'),
+        WATCH_CONFIG.SSE_HEARTBEAT_INTERVAL_MS
+      );
+      req.on('close', () => {
+        clearInterval(heartbeat);
+        const i = clients.indexOf(res);
+        if (i !== -1) clients.splice(i, 1);
+      });
+      return;
+    }
+
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(cachedHtml);
+  });
+
+  server.listen(port, () => {
+    const url = `http://localhost:${port}`;
+    log.raw('');
+    log.raw(`  ${link(url)}`);
+    log.raw('');
+    log.step(WATCH_MESSAGES.WATCHING_FILE(path.relative(process.cwd(), absInput)));
+    log.raw('');
+  });
+
+  onShutdown(() => {
+    server.close();
+    clients.forEach((c) => c.end());
+    log.raw('');
+    log.step(WATCH_MESSAGES.SERVER_STOPPED);
+  });
+
+  if (opts.open) {
+    const { default: open } = await import('open').catch(() => ({ default: null }));
+    if (open) open(`http://localhost:${port}`).catch(() => {});
+  }
+
+  let debounce: NodeJS.Timeout | null = null;
+
+  fs.watch(absInput, (eventType) => {
+    if (eventType !== 'change') return;
+    if (debounce) clearTimeout(debounce);
+    // Used debounce delay timing variable here
+    debounce = setTimeout(async () => {
+      log.verbose(WATCH_MESSAGES.CHANGE_DETECTED);
+
+      try {
+        const { html, slideCount } = await runCompile(absInput, opts, log, { injectReload: true });
+        cachedHtml = html;
+        log.success(WATCH_MESSAGES.RECOMPILE_SUCCESS(slideCount));
+      } catch (err) {
+        log.error(err);
+        cachedHtml = buildErrorHtml(err);
+      }
+
+      for (const client of clients) {
+        try {
+          client.write('data: reload\n\n');
+        } catch {
+          /* client disconnected */
+        }
+      }
+    }, WATCH_CONFIG.DEBOUNCE_DELAY_MS);
+  });
+}

--- a/packages/cli/src/constants/exports/pdfConstants.ts
+++ b/packages/cli/src/constants/exports/pdfConstants.ts
@@ -1,0 +1,52 @@
+import { icons } from '../../assets/index.js';
+
+export const PDF_CONFIG = {
+  DEFAULT_TIMEOUT_MS: 30_000,
+  CHROME_CANDIDATES: [
+    process.env['CHROME_PATH'],
+    process.env['CHROMIUM_PATH'],
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium-browser',
+    '/usr/bin/chromium',
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+  ].filter(Boolean) as string[],
+  CHROME_ARGS: (outputPath: string, htmlPath: string) => [
+    '--headless',
+    '--disable-gpu',
+    '--no-sandbox',
+    '--disable-setuid-sandbox',
+    '--disable-dev-shm-usage',
+    `--print-to-pdf=${outputPath}`,
+    '--print-to-pdf-no-header',
+    htmlPath,
+  ],
+} as const;
+
+export const PDF_MESSAGES = {
+  CHROME_NOT_FOUND:
+    'PDF export requires Google Chrome or Chromium.\n' +
+    `  ${icons.rightArrow} Install Chrome/Chromium, or set the CHROME_PATH environment variable.\n` +
+    `  ${icons.rightArrow} Example: CHROME_PATH=/usr/bin/chromium mdslide compile slides.md -f pdf`,
+
+  TIMEOUT_ERROR: (timeoutMs: number) =>
+    `PDF export timed out after ${timeoutMs / 1000}s.\n` +
+    `  ${icons.rightArrow} Chrome process was killed.\n` +
+    `  ${icons.rightArrow} Increase timeout with --pdf-timeout <ms> or check if the HTML file is valid.`,
+
+  EMPTY_OUTPUT_ERROR: (outputPath: string) =>
+    `Chrome exited successfully but did not write a PDF to ${outputPath}.\n` +
+    `  ${icons.rightArrow} Ensure the output directory exists and is writable.`,
+
+  CHROME_EXIT_ERROR: (code: number | null, stderrText: string) =>
+    `Chrome exited with code ${code}.\n` +
+    (stderrText
+      ? `  Chrome stderr:\n  ${stderrText.split('\n').join('\n  ')}`
+      : '  No stderr output.'),
+
+  START_FAILURE_ERROR: (message: string, chromeBin: string) =>
+    `Failed to start Chrome: ${message}\n` +
+    `  → Chrome binary: ${chromeBin}\n` +
+    `  ${icons.rightArrow} Set CHROME_PATH to override.`,
+} as const;

--- a/packages/cli/src/constants/exports/pptxConstants.ts
+++ b/packages/cli/src/constants/exports/pptxConstants.ts
@@ -1,0 +1,59 @@
+import { PptxTheme } from '../../types/index.js';
+
+export const PPTX_THEMES: Record<string, PptxTheme> = {
+  light: {
+    bg: 'FAF9F6',
+    text: '1E293B',
+    accent: '4F46E5',
+    font: 'Trebuchet MS',
+    cardBg: 'F1F5F9',
+  },
+  dark: {
+    bg: '0F172A',
+    text: 'F1F5F9',
+    accent: '38BDF8',
+    font: 'Trebuchet MS',
+    cardBg: '1E293B',
+  },
+  notion: {
+    bg: 'FFFFFF',
+    text: '37352F',
+    accent: '0F7B6C',
+    font: 'Arial',
+    cardBg: 'F4F4F5',
+  },
+  terminal: {
+    bg: '0B0F19',
+    text: '10B981',
+    accent: '34D399',
+    font: 'Courier New',
+    cardBg: '111827',
+  },
+  gradient: {
+    bg: '1E1B4B',
+    text: 'F8FAFC',
+    accent: 'C084FC',
+    font: 'Georgia',
+    cardBg: '312E81',
+  },
+  corporate: {
+    bg: 'FFFFFF',
+    text: '0F172A',
+    accent: '0EA5E9',
+    font: 'Calibri',
+    cardBg: 'F8FAFC',
+  },
+  solarized: {
+    bg: 'FDF6E3',
+    text: '073642',
+    accent: '268BD2',
+    font: 'Georgia',
+    cardBg: 'EEE8D5',
+  },
+};
+
+export const BULLET_CHARS: Record<number, string> = {
+  0: '2022',
+  1: '25E6',
+  2: '25AA',
+};

--- a/packages/cli/src/constants/index.ts
+++ b/packages/cli/src/constants/index.ts
@@ -2,3 +2,7 @@ export * from './sampleConfig.js';
 export * from './sampleSlide.js';
 export * from './terminalEscapeCode.js';
 export * from './tellyTypewriter.js';
+export * from './logs/initCommandLogs.js';
+export * from './logs/validationCommandLogs.js';
+export * from './logs/watchCommandLogs.js';
+export * from './logs/compileComandLogs.js';

--- a/packages/cli/src/constants/logs/compileComandLogs.ts
+++ b/packages/cli/src/constants/logs/compileComandLogs.ts
@@ -1,0 +1,26 @@
+export const COMPILE_CONFIG = {
+  DEFAULT_FORMAT: 'html' as const,
+  SUPPORTED_FORMATS: ['html', 'pdf', 'pptx'] as const,
+  CHROME_CANDIDATES: [
+    process.env['CHROME_PATH'],
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium-browser',
+    '/usr/bin/chromium',
+  ].filter(Boolean) as string[],
+  CHROME_FLAGS: '--headless --disable-gpu --no-sandbox',
+} as const;
+
+export const COMPILE_MESSAGES = {
+  CORE_NOT_FOUND: 'Cannot find @mindfiredigital/mdslide-core. Make sure the core package is built.',
+  SPINNER_START: (filename: string, format: string) =>
+    `Compiling ${filename} → ${format.toUpperCase()}`,
+  SPINNER_LAUNCHING_CHROME: 'Launching Chrome for PDF export...',
+  SUCCESS_SUMMARY: (relativePath: string, slideCount: number, warningCount: number) => {
+    const summaryText =
+      warningCount > 0
+        ? `(${warningCount} warning${warningCount > 1 ? 's' : ''})`
+        : `— ${slideCount} slide${slideCount !== 1 ? 's' : ''}`;
+    return `${relativePath}  ${summaryText}`;
+  },
+} as const;

--- a/packages/cli/src/constants/logs/initCommandLogs.ts
+++ b/packages/cli/src/constants/logs/initCommandLogs.ts
@@ -1,0 +1,19 @@
+export const INIT_MESSAGES = {
+  SLIDES_CREATED: 'Created slides.md',
+  SLIDES_EXISTS: 'slides.md already exists - skipping (use --force to overwrite)',
+  CONFIG_CREATED: 'Created mdslide.config.ts',
+  CONFIG_EXISTS: 'mdslide.config.ts already exists - skipping (use --force to overwrite)',
+  SCRIPTS_ADDED: 'Added "dev" and "build" scripts to package.json',
+  NEXT_STEPS: 'Run `mdslide watch slides.md` to start the live preview server.',
+} as const;
+
+export const FILE_NAME = {
+  SAMPLE_FILE_NAME: 'slides.md',
+  SAMPLE_CONFIG_FILE_NAME: 'mdslide.config.ts',
+  PACKAGE_NAME: 'package.json',
+};
+
+export const DEV_COMMANDS = {
+  DEV: 'mdslide watch slides.md',
+  BUILD: 'mdslide compile slides.md',
+};

--- a/packages/cli/src/constants/logs/validationCommandLogs.ts
+++ b/packages/cli/src/constants/logs/validationCommandLogs.ts
@@ -1,0 +1,36 @@
+import { COLORS, STYLES } from '../index.js';
+
+export const VALIDATION_RULES = {
+  MAX_LINES_PER_SLIDE: 30,
+} as const;
+
+export const VALIDATION_MESSAGES = {
+  NO_SEPARATORS: {
+    message: 'No slide separators (---) found.',
+    hint: 'Separate slides with a line containing only ---',
+  },
+  EMPTY_SLIDE: {
+    message: 'Slide is empty.',
+  },
+  NO_HEADING: {
+    message: 'Slide has no heading.',
+    hint: 'Add a # heading to give the slide a title.',
+  },
+  UNCLOSED_CODE_FENCE: {
+    message: 'Unclosed code fence (```).',
+    hint: 'Make sure every opening ``` has a matching closing ```.',
+  },
+
+  OVERFLOW: (lineCount: number) => ({
+    message: `Slide has ${lineCount} lines — may overflow in the browser.`,
+    hint: 'Split into multiple slides.',
+  }),
+
+  LOG_SUCCESS: (filename: string, slideCount: number) =>
+    `${filename} — ${slideCount} slides, no issues found`,
+
+  LOG_SUMMARY: (slideCount: number, errors: number, warnings: number) =>
+    `  ${COLORS.grey}${slideCount} slides — ${errors} error${errors !== 1 ? 's' : ''}, ${warnings} warning${warnings !== 1 ? 's' : ''}${STYLES.reset}`,
+
+  LOG_LOCATION: (slideNum: number | undefined) => (slideNum != null ? `  (slide ${slideNum})` : ''),
+} as const;

--- a/packages/cli/src/constants/logs/watchCommandLogs.ts
+++ b/packages/cli/src/constants/logs/watchCommandLogs.ts
@@ -1,0 +1,51 @@
+export const WATCH_CONFIG = {
+  PORT_SCAN_RANGE: 20,
+  DEBOUNCE_DELAY_MS: 80,
+  SSE_HEARTBEAT_INTERVAL_MS: 15_000,
+  LIVE_RELOAD_PATH: '/~live-reload',
+  PORT: 3500,
+} as const;
+
+export const WATCH_MESSAGES = {
+  SPINNER_START: (filename: string) => `Compiling ${filename}`,
+  SPINNER_READY: 'Ready',
+  SPINNER_FAIL: 'Compilation failed — showing error overlay',
+  SERVER_STOPPED: 'Server stopped.',
+  CHANGE_DETECTED: 'Change detected — recompiling...',
+  RECOMPILE_SUCCESS: (slideCount: number) =>
+    `Recompiled — ${slideCount} slide${slideCount !== 1 ? 's' : ''}`,
+  WATCHING_FILE: (relativePath: string) => `Watching ${relativePath}`,
+} as const;
+
+export const ERROR_OVERLAY_TEMPLATE = (
+  escapedMessage: string,
+  hint?: string
+) => `<!DOCTYPE html><html><head><meta charset="utf-8">
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: ui-monospace, monospace;
+    background: #0f0f0f; color: #f5f5f5;
+    display: flex; align-items: center; justify-content: center;
+    min-height: 100vh; padding: 2rem;
+  }
+  .card {
+    background: #1a1a1a; border: 1px solid #e05252;
+    border-radius: 10px; padding: 2rem; max-width: 680px; width: 100%;
+  }
+  .title { color: #e05252; font-size: 1rem; font-weight: 600; margin-bottom: .75rem; }
+  .message { color: #f0f0f0; font-size: .9rem; line-height: 1.6; }
+  .hint { color: #9ca3af; font-size: .85rem; margin-top: 1rem; }
+  .hint span { color: #60b4ff; }
+</style>
+</head><body>
+<div class="card">
+  <div class="title">⚠ Compilation Error</div>
+  <div class="message">${escapedMessage}</div>
+  ${hint ? `<div class="hint">→ <span>${hint}</span></div>` : ''}
+</div>
+<script>
+const es = new EventSource('${WATCH_CONFIG.LIVE_RELOAD_PATH}');
+es.onmessage = (e) => { if (e.data === 'reload') location.reload(); };
+</script>
+</body></html>`;

--- a/packages/cli/src/exports/helper/pptxEditableSlideHelper.ts
+++ b/packages/cli/src/exports/helper/pptxEditableSlideHelper.ts
@@ -1,0 +1,218 @@
+import type { SlideDeck, SlideNode } from '@mindfiredigital/mdslide-shared';
+import { FlatListLine, PptxTheme } from '../../types/index.js';
+import { BULLET_CHARS } from '../../constants/exports/pptxConstants.js';
+import path from 'path';
+
+// Recursively extract text from SlideNode into pptx array
+function nodeToTextProps(node: SlideNode, theme: PptxTheme): any[] {
+  const props: any[] = [];
+
+  const fontOptions = {
+    fontFace: theme.font,
+    color: theme.text,
+  };
+
+  if (node.type === 'text') {
+    props.push({
+      text: node.value || '',
+      options: { ...fontOptions },
+    });
+  } else if (node.type === 'strong') {
+    if (node.children) {
+      node.children.forEach((c) => {
+        const childProps = nodeToTextProps(c, theme);
+        childProps.forEach((cp) => {
+          cp.options = { ...cp.options, bold: true };
+          props.push(cp);
+        });
+      });
+    }
+  } else if (node.type === 'emphasis') {
+    if (node.children) {
+      node.children.forEach((c) => {
+        const childProps = nodeToTextProps(c, theme);
+        childProps.forEach((cp) => {
+          cp.options = { ...cp.options, italic: true };
+          props.push(cp);
+        });
+      });
+    }
+  } else if (node.type === 'inlineCode') {
+    props.push({
+      text: node.value || '',
+      options: {
+        ...fontOptions,
+        fontFace: 'Courier New',
+        color: theme.accent,
+      },
+    });
+  } else if (node.type === 'link') {
+    const textVal = node.children
+      ? node.children.map((c) => c.value || '').join('')
+      : node.value || 'Link';
+    props.push({
+      text: textVal,
+      options: {
+        ...fontOptions,
+        color: theme.accent,
+        hyperlink: { url: node.url || '' },
+      },
+    });
+  } else if (node.children) {
+    node.children.forEach((c) => {
+      props.push(...nodeToTextProps(c, theme));
+    });
+  }
+
+  return props;
+}
+
+// Recursively extract text from SlideNode into a plain string
+function nodeToPlainText(node: SlideNode): string {
+  if (node.value) return node.value;
+  if (node.children) {
+    return node.children.map(nodeToPlainText).join('');
+  }
+  return '';
+}
+
+// Recursively find all image URLs inside a slide
+function findImagesInNodes(nodes: SlideNode[]): string[] {
+  const urls: string[] = [];
+  function traverse(n: SlideNode) {
+    if (n.type === 'image' && n.url) {
+      urls.push(n.url);
+    }
+    if (n.children) {
+      n.children.forEach(traverse);
+    }
+  }
+  nodes.forEach(traverse);
+  return urls;
+}
+
+// Resolve image path relative to markdown baseDir if it is a local file
+function resolveImagePath(imgUrl: string, baseDir?: string): string {
+  if (!imgUrl) return '';
+  if (imgUrl.startsWith('http://') || imgUrl.startsWith('https://')) {
+    return imgUrl;
+  }
+  if (path.isAbsolute(imgUrl)) {
+    return imgUrl;
+  }
+  if (baseDir) {
+    return path.resolve(baseDir, imgUrl);
+  }
+  return path.resolve(imgUrl);
+}
+
+function getBulletCharCode(indent: number): string {
+  return BULLET_CHARS[indent] ?? BULLET_CHARS[2];
+}
+
+// Font size shrinks slightly at deeper indent levels, floored at 10pt
+function getBulletFontSize(baseFontSize: number, indent: number): number {
+  return Math.max(baseFontSize - indent * 1.5, 10);
+}
+
+function extractFlatListLines(node: SlideNode, theme: PptxTheme, indent = 0): FlatListLine[] {
+  const lines: FlatListLine[] = [];
+
+  if (node.type === 'list') {
+    if (node.children) {
+      node.children.forEach((item) => {
+        if (item.type === 'listItem' && item.children) {
+          const itemText: any[] = [];
+          const nestedLists: SlideNode[] = [];
+
+          item.children.forEach((c) => {
+            if (c.type === 'list') {
+              nestedLists.push(c);
+            } else {
+              itemText.push(...nodeToTextProps(c, theme));
+            }
+          });
+
+          if (itemText.length > 0) {
+            lines.push({ text: itemText, bullet: true, indent });
+          }
+
+          nestedLists.forEach((l) => {
+            lines.push(...extractFlatListLines(l, theme, indent + 1));
+          });
+        }
+      });
+    }
+  }
+
+  return lines;
+}
+
+function pushParagraphNodeToRuns(
+  node: SlideNode,
+  runsArray: any[],
+  theme: PptxTheme,
+  fontSize: number,
+  isLastNode: boolean
+) {
+  const runs = nodeToTextProps(node, theme);
+  runs.forEach((run, runIdx) => {
+    const isLastRun = runIdx === runs.length - 1;
+    const runOptions: any = {
+      ...run.options,
+      fontSize,
+      fontFace: theme.font,
+      color: theme.text,
+    };
+    if (isLastRun && !isLastNode) {
+      runOptions.breakLine = true;
+    }
+    runsArray.push({ text: run.text, options: runOptions });
+  });
+}
+
+function pushListLinesToRuns(
+  listLines: FlatListLine[],
+  runsArray: any[],
+  theme: PptxTheme,
+  baseFontSize: number,
+  _isLastNode: boolean
+) {
+  listLines.forEach((line) => {
+    if (line.text.length === 0) return;
+
+    const fontSize = getBulletFontSize(baseFontSize, line.indent);
+
+    line.text.forEach((run, runIdx) => {
+      const isFirstRun = runIdx === 0;
+
+      const runOptions: any = {
+        ...run.options,
+        fontSize,
+        fontFace: theme.font,
+        color: theme.text,
+      };
+
+      if (isFirstRun) {
+        // bullet + indentLevel only on the first run   this triggers a new
+        // paragraph in pptxgenjs and sets the indent for the whole line
+        runOptions.bullet = { characterCode: getBulletCharCode(line.indent) };
+        runOptions.indentLevel = line.indent;
+      }
+      // no breakLine on any bullet run   pptxgenjs handles paragraph breaks
+      // automatically when it sees `bullet` on the next line's first run
+
+      runsArray.push({ text: run.text, options: runOptions });
+    });
+  });
+}
+
+export {
+  nodeToPlainText,
+  nodeToTextProps,
+  findImagesInNodes,
+  resolveImagePath,
+  extractFlatListLines,
+  pushParagraphNodeToRuns,
+  pushListLinesToRuns,
+};

--- a/packages/cli/src/exports/pdfExports.ts
+++ b/packages/cli/src/exports/pdfExports.ts
@@ -5,10 +5,10 @@ import { execFileSync } from 'child_process';
 import { PdfExportOptions } from '../types/index.js';
 import { PDF_CONFIG, PDF_MESSAGES } from '../constants/index.js';
 
-function findChromeBinary(): string | null {
+export function findChromeBinary(): string | null {
   for (const bin of PDF_CONFIG.CHROME_CANDIDATES) {
     try {
-      execFileSync(`"${bin}" --version > /dev/null 2>&1`);
+      execFileSync(bin, ['--version'], { stdio: 'ignore' });
       return bin;
     } catch {}
   }

--- a/packages/cli/src/exports/pdfExports.ts
+++ b/packages/cli/src/exports/pdfExports.ts
@@ -1,0 +1,84 @@
+import fs from 'fs';
+import path from 'path';
+import { spawn } from 'child_process';
+import { execFileSync } from 'child_process';
+import { PdfExportOptions } from '../types/index.js';
+import { PDF_CONFIG, PDF_MESSAGES } from '../constants/index.js';
+
+function findChromeBinary(): string | null {
+  for (const bin of PDF_CONFIG.CHROME_CANDIDATES) {
+    try {
+      execFileSync(`"${bin}" --version > /dev/null 2>&1`);
+      return bin;
+    } catch {}
+  }
+  return null;
+}
+
+export function exportToPdf(
+  htmlPath: string,
+  outputPath: string,
+  opts: PdfExportOptions = {}
+): Promise<void> {
+  const timeoutMs = opts.timeoutMs ?? PDF_CONFIG.DEFAULT_TIMEOUT_MS;
+  const chromeBin = opts.chromePath ?? findChromeBinary();
+
+  if (!chromeBin) {
+    return Promise.reject(new Error(PDF_MESSAGES.CHROME_NOT_FOUND));
+  }
+
+  const args = PDF_CONFIG.CHROME_ARGS(outputPath, htmlPath);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(chromeBin, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    const stderr: Buffer[] = [];
+
+    child.stderr?.on('data', (chunk: Buffer) => stderr.push(chunk));
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(PDF_MESSAGES.TIMEOUT_ERROR(timeoutMs)));
+    }, timeoutMs);
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+
+      if (code === 0) {
+        if (!fs.existsSync(outputPath) || fs.statSync(outputPath).size === 0) {
+          reject(new Error(PDF_MESSAGES.EMPTY_OUTPUT_ERROR(outputPath)));
+          return;
+        }
+        resolve();
+        return;
+      }
+
+      const stderrText = Buffer.concat(stderr).toString().trim();
+      reject(new Error(PDF_MESSAGES.CHROME_EXIT_ERROR(code, stderrText)));
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(new Error(PDF_MESSAGES.START_FAILURE_ERROR(err.message, chromeBin)));
+    });
+  });
+}
+
+export async function compileToPdf(
+  html: string,
+  outputPath: string,
+  opts: PdfExportOptions = {}
+): Promise<void> {
+  const dir = path.dirname(path.resolve(outputPath));
+  const tempPath = path.join(dir, `.mdslide-tmp-${Date.now()}.html`);
+
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(tempPath, html, 'utf8');
+
+  try {
+    await exportToPdf(tempPath, path.resolve(outputPath), opts);
+  } finally {
+    try {
+      fs.unlinkSync(tempPath);
+    } catch {}
+  }
+}

--- a/packages/cli/src/exports/pptxEditableExporter.ts
+++ b/packages/cli/src/exports/pptxEditableExporter.ts
@@ -1,0 +1,365 @@
+import fs from 'fs';
+import path from 'path';
+import pptxgen from 'pptxgenjs';
+import type { SlideDeck } from '@mindfiredigital/mdslide-shared';
+import { PPTX_THEMES } from '../constants/exports/pptxConstants.js';
+import {
+  nodeToPlainText,
+  nodeToTextProps,
+  findImagesInNodes,
+  resolveImagePath,
+  extractFlatListLines,
+  pushParagraphNodeToRuns,
+  pushListLinesToRuns,
+} from './helper/pptxEditableSlideHelper.js';
+
+export async function compileToEditablePptx(
+  deck: SlideDeck,
+  outputPath: string,
+  options: { theme?: string; baseDir?: string } = {}
+): Promise<void> {
+  const pptx = new (pptxgen as any)();
+  pptx.layout = 'LAYOUT_16x9';
+
+  const themeName = options.theme ?? String(deck.meta?.theme ?? 'light');
+  const theme = PPTX_THEMES[themeName] || PPTX_THEMES.light;
+  const baseDir = options.baseDir;
+
+  for (const slide of deck.slides) {
+    const pptxSlide = pptx.addSlide();
+
+    // Set background color matching the selected theme
+    pptxSlide.background = { fill: theme.bg };
+
+    // Main Title
+    if (slide.title && slide.type !== 'title' && slide.type !== 'statement') {
+      pptxSlide.addText(slide.title, {
+        x: 0.8,
+        y: 0.4,
+        w: 8.4,
+        h: 0.8,
+        fontSize: 26,
+        bold: true,
+        fontFace: theme.font,
+        color: theme.accent,
+        valign: 'middle',
+      });
+    }
+
+    // Render slide contents based on layout type
+    if (slide.type === 'title') {
+      // Large centered title layout
+      pptxSlide.addText(slide.title || 'Title', {
+        x: 0.8,
+        y: 1.8,
+        w: 8.4,
+        h: 1.2,
+        align: 'center',
+        fontSize: 44,
+        bold: true,
+        fontFace: theme.font,
+        color: theme.accent,
+      });
+
+      if (slide.content && slide.content.length > 0) {
+        const textRuns: any[] = [];
+        slide.content.forEach((node, nodeIdx) => {
+          const isLastNode = nodeIdx === slide.content.length - 1;
+          pushParagraphNodeToRuns(node, textRuns, theme, 20, isLastNode);
+        });
+
+        if (textRuns.length > 0) {
+          pptxSlide.addText(textRuns, {
+            x: 0.8,
+            y: 3.2,
+            w: 8.4,
+            h: 1.5,
+            align: 'center',
+          });
+        }
+      }
+    } else if (slide.type === 'statement') {
+      // Large statement layout
+      const textRuns: any[] = [];
+      if (slide.title) {
+        textRuns.push({
+          text: slide.title + '\n\n',
+          options: { bold: true, fontSize: 32, color: theme.accent, fontFace: theme.font },
+        });
+      }
+      slide.content.forEach((node, nodeIdx) => {
+        const isLastNode = nodeIdx === slide.content.length - 1;
+        pushParagraphNodeToRuns(node, textRuns, theme, 24, isLastNode);
+      });
+
+      pptxSlide.addText(textRuns, {
+        x: 0.8,
+        y: 1.2,
+        w: 8.4,
+        h: 3.4,
+        align: 'center',
+        valign: 'middle',
+      });
+    } else if (slide.type === 'quote') {
+      // Blockquote card layout
+      const quoteText: any[] = [];
+      const quoteNode = slide.content.find((n) => n.type === 'blockquote');
+
+      const nodesToRender = quoteNode && quoteNode.children ? quoteNode.children : slide.content;
+      nodesToRender.forEach((node, nodeIdx) => {
+        const isLastNode = nodeIdx === nodesToRender.length - 1;
+        const runs = nodeToTextProps(node, theme);
+        runs.forEach((run, runIdx) => {
+          const isLastRun = runIdx === runs.length - 1;
+          const runOptions: any = {
+            ...run.options,
+            fontSize: 18,
+            italic: true,
+            fontFace: theme.font,
+            color: theme.text,
+          };
+          if (isLastRun && !isLastNode) {
+            runOptions.breakLine = true;
+          }
+          quoteText.push({ text: run.text, options: runOptions });
+        });
+      });
+
+      pptxSlide.addText(quoteText, {
+        x: 1.0,
+        y: 1.4,
+        w: 8.0,
+        h: 3.2,
+        valign: 'middle',
+        fill: { color: theme.cardBg },
+        line: { color: theme.accent, width: 2 },
+        margin: 20,
+      });
+    } else if (slide.type === 'code') {
+      // Code box container layout
+      const codeNode = slide.content.find((n) => n.type === 'code');
+      const codeVal = codeNode?.value || '';
+
+      pptxSlide.addText(codeVal, {
+        x: 0.8,
+        y: 1.3,
+        w: 8.4,
+        h: 3.8,
+        fontSize: 10,
+        fontFace: 'Courier New',
+        color: theme.text,
+        valign: 'top',
+        fill: { color: theme.cardBg },
+        line: { color: theme.accent, width: 1 },
+        margin: 15,
+      });
+    } else if (slide.type === 'visual') {
+      // Large centered image layout
+      let imgUrl = '';
+      slide.content.forEach((node) => {
+        if (node.type === 'image') {
+          imgUrl = node.url || '';
+        } else if (node.children) {
+          node.children.forEach((c) => {
+            if (c.type === 'image') imgUrl = c.url || '';
+          });
+        }
+      });
+
+      if (imgUrl) {
+        const hasTitle = !!slide.title;
+        pptxSlide.addImage({
+          path: resolveImagePath(imgUrl, baseDir),
+          x: 1.0,
+          y: hasTitle ? 1.2 : 0.5,
+          w: 8.0,
+          h: hasTitle ? 4.0 : 4.6,
+        });
+      } else {
+        const textRuns: any[] = [];
+        slide.content.forEach((node, nodeIdx) => {
+          const isLastNode = nodeIdx === slide.content.length - 1;
+          pushParagraphNodeToRuns(node, textRuns, theme, 16, isLastNode);
+        });
+
+        pptxSlide.addText(textRuns, {
+          x: 0.8,
+          y: 1.4,
+          w: 8.4,
+          h: 3.6,
+          valign: 'top',
+        });
+      }
+    } else if (slide.type === 'table') {
+      // Tabular comparison grid layout
+      const tableNode = slide.content.find((n) => n.type === 'table');
+      if (tableNode && tableNode.children) {
+        const rows: any[] = [];
+        tableNode.children.forEach((rowNode) => {
+          const cells: any[] = [];
+          if (rowNode.children) {
+            rowNode.children.forEach((cellNode) => {
+              const cellText = cellNode.children
+                ? cellNode.children.map(nodeToPlainText).join('')
+                : cellNode.value || '';
+              cells.push({
+                text: cellText,
+                options: {
+                  fill: cellNode.header ? { color: theme.accent } : { color: theme.cardBg },
+                  color: cellNode.header ? theme.bg : theme.text,
+                  bold: cellNode.header,
+                  fontFace: theme.font,
+                  fontSize: 12,
+                },
+              });
+            });
+          }
+          rows.push(cells);
+        });
+
+        pptxSlide.addTable(rows, {
+          x: 0.8,
+          y: 1.4,
+          w: 8.4,
+          h: 3.6,
+        });
+      }
+    } else if (slide.type === 'split') {
+      // Split layout
+      const leftCol = slide.content[0];
+      const rightCol = slide.content[1];
+
+      // Left column
+      if (leftCol && leftCol.type === 'column' && leftCol.children) {
+        const leftRuns: any[] = [];
+        leftCol.children.forEach((node, nodeIdx) => {
+          const isLastNode = nodeIdx === (leftCol.children?.length ?? 0) - 1;
+          if (node.type === 'list') {
+            const listLines = extractFlatListLines(node, theme);
+            pushListLinesToRuns(listLines, leftRuns, theme, 14, isLastNode);
+          } else {
+            pushParagraphNodeToRuns(node, leftRuns, theme, 14, isLastNode);
+          }
+        });
+
+        if (leftRuns.length > 0) {
+          pptxSlide.addText(leftRuns, {
+            x: 0.8,
+            y: 1.4,
+            w: 3.9,
+            h: 3.6,
+            valign: 'top',
+          });
+        }
+      }
+
+      // Right column
+      if (rightCol && rightCol.type === 'column' && rightCol.children) {
+        const rightChild = rightCol.children[0];
+
+        if (rightChild && rightChild.type === 'image') {
+          pptxSlide.addImage({
+            path: resolveImagePath(rightChild.url || '', baseDir),
+            x: 5.0,
+            y: 1.4,
+            w: 4.2,
+            h: 3.6,
+          });
+        } else if (rightChild && rightChild.type === 'code') {
+          pptxSlide.addText(rightChild.value || '', {
+            x: 5.0,
+            y: 1.4,
+            w: 4.2,
+            h: 3.6,
+            fontSize: 9.5,
+            fontFace: 'Courier New',
+            color: theme.text,
+            valign: 'top',
+            fill: { color: theme.cardBg },
+            line: { color: theme.accent, width: 1 },
+            margin: 12,
+          });
+        } else {
+          const rightRuns: any[] = [];
+          rightCol.children.forEach((node, nodeIdx) => {
+            const isLastNode = nodeIdx === (rightCol.children?.length ?? 0) - 1;
+            pushParagraphNodeToRuns(node, rightRuns, theme, 14, isLastNode);
+          });
+
+          if (rightRuns.length > 0) {
+            pptxSlide.addText(rightRuns, {
+              x: 5.0,
+              y: 1.4,
+              w: 4.2,
+              h: 3.6,
+              valign: 'top',
+            });
+          }
+        }
+      }
+    } else {
+      // Default bullets/content layout
+      const allTextRuns: any[] = [];
+      const imageUrls = findImagesInNodes(slide.content);
+
+      slide.content.forEach((node, nodeIdx) => {
+        const isLastNode = nodeIdx === slide.content.length - 1;
+        if (node.type === 'list') {
+          const listLines = extractFlatListLines(node, theme);
+          pushListLinesToRuns(listLines, allTextRuns, theme, 16, isLastNode);
+        } else {
+          pushParagraphNodeToRuns(node, allTextRuns, theme, 16, isLastNode);
+        }
+      });
+
+      const hasImages = imageUrls.length > 0;
+      const textHeight = hasImages ? 2.0 : 3.8;
+
+      if (allTextRuns.length > 0) {
+        pptxSlide.addText(allTextRuns, {
+          x: 0.8,
+          y: 1.3,
+          w: 8.4,
+          h: textHeight,
+          valign: 'top',
+        });
+      }
+
+      if (hasImages) {
+        const N = imageUrls.length;
+        const gap = 0.3;
+        const totalWidth = 8.4;
+        const imageY = 3.5;
+        const imageHeight = 1.7;
+
+        if (N === 1) {
+          const imgWidth = 4.5;
+          const imgX = 0.8 + (totalWidth - imgWidth) / 2;
+          pptxSlide.addImage({
+            path: resolveImagePath(imageUrls[0]!, baseDir),
+            x: imgX,
+            y: imageY,
+            w: imgWidth,
+            h: imageHeight,
+          });
+        } else {
+          const imgWidth = (totalWidth - gap * (N - 1)) / N;
+          imageUrls.forEach((url, i) => {
+            const imgX = 0.8 + i * (imgWidth + gap);
+            pptxSlide.addImage({
+              path: resolveImagePath(url, baseDir),
+              x: imgX,
+              y: imageY,
+              w: imgWidth,
+              h: imageHeight,
+            });
+          });
+        }
+      }
+    }
+  }
+
+  // Write output file, creating any missing parent directories first
+  fs.mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true });
+  await pptx.writeFile({ fileName: path.resolve(outputPath) });
+}

--- a/packages/cli/src/exports/pptxExports.ts
+++ b/packages/cli/src/exports/pptxExports.ts
@@ -1,0 +1,2 @@
+export { compileToScreenshotPptx } from './pptxScreenshotExporter.js';
+export { compileToEditablePptx } from './pptxEditableExporter.js';

--- a/packages/cli/src/exports/pptxScreenshotExporter.ts
+++ b/packages/cli/src/exports/pptxScreenshotExporter.ts
@@ -1,0 +1,249 @@
+import fs from 'fs';
+import path from 'path';
+import http from 'http';
+import net from 'net';
+import os from 'os';
+import { spawn } from 'child_process';
+import pptxgen from 'pptxgenjs';
+import { findChromeBinary } from './pdfExports.js';
+import { ScreenshotPptxOptions } from '../types/index.js';
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const s = net.createServer();
+    s.listen(0, () => {
+      const addr = s.address() as net.AddressInfo;
+      s.close(() => resolve(addr.port));
+    });
+    s.on('error', reject);
+  });
+}
+
+// Local HTTP server for serving slide HTML and its static assets
+function serveHtml(html: string, port: number, baseDir: string): Promise<() => void> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const urlPath = req.url ? req.url.split('?')[0] : '/';
+
+      if (urlPath === '/' || urlPath === '/index.html') {
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.end(html);
+        return;
+      }
+
+      // Try serving static files relative to baseDir
+      const filePath = path.join(baseDir, decodeURIComponent(urlPath));
+      fs.stat(filePath, (err, stats) => {
+        if (err || !stats.isFile()) {
+          res.writeHead(404, { 'Content-Type': 'text/plain' });
+          res.end('Not Found');
+          return;
+        }
+
+        let contentType = 'application/octet-stream';
+        const ext = path.extname(filePath).toLowerCase();
+        if (ext === '.css') contentType = 'text/css';
+        else if (ext === '.js') contentType = 'application/javascript';
+        else if (ext === '.json') contentType = 'application/json';
+        else if (ext === '.png') contentType = 'image/png';
+        else if (ext === '.jpg' || ext === '.jpeg') contentType = 'image/jpeg';
+        else if (ext === '.gif') contentType = 'image/gif';
+        else if (ext === '.svg') contentType = 'image/svg+xml';
+        else if (ext === '.woff') contentType = 'font/woff';
+        else if (ext === '.woff2') contentType = 'font/woff2';
+        else if (ext === '.ttf') contentType = 'font/ttf';
+
+        res.writeHead(200, { 'Content-Type': contentType });
+        fs.createReadStream(filePath).pipe(res);
+      });
+    });
+
+    server.listen(port, '127.0.0.1', () => {
+      resolve(() => server.close());
+    });
+    server.once('error', reject);
+  });
+}
+
+function screenshotSlide(
+  chromeBin: string,
+  url: string,
+  outputPng: string,
+  width: number,
+  height: number,
+  timeoutMs: number
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const args = [
+      '--headless',
+      '--disable-gpu',
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+      '--hide-scrollbars',
+      '--run-all-compositor-stages-before-draw',
+      '--virtual-time-budget=5000',
+      `--window-size=${width},${height}`,
+      `--screenshot=${outputPng}`,
+      url,
+    ];
+
+    const child = spawn(chromeBin, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    const stderr: Buffer[] = [];
+
+    child.stderr?.on('data', (d: Buffer) => stderr.push(d));
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`Screenshot timed out for: ${url}`));
+    }, timeoutMs);
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (code === 0 && fs.existsSync(outputPng)) {
+        resolve();
+      } else {
+        reject(
+          new Error(
+            `Chrome screenshot failed (code ${code}) for ${url}\n` +
+              Buffer.concat(stderr).toString().slice(0, 500)
+          )
+        );
+      }
+    });
+
+    child.on('error', (e) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+  });
+}
+
+// inject slide selector script into the HTML
+function injectSlideSelector(html: string): string {
+  const css = `
+<style>
+  /* Disable all animations, transitions, and hide controls for screenshot mode */
+  *, *::before, *::after {
+    transition: none !important;
+    animation: none !important;
+    transition-duration: 0s !important;
+    animation-duration: 0s !important;
+  }
+  .dokContainer, .progressBarContainer {
+    display: none !important;
+  }
+  /* Ensure the active slide is instantly visible and positioned at 0,0 */
+  .slide.active {
+    opacity: 1 !important;
+    transform: none !important;
+    display: flex !important;
+  }
+  .slide:not(.active) {
+    opacity: 0 !important;
+    display: none !important;
+  }
+</style>
+`;
+
+  const script = `
+<script>
+(function() {
+  var idx = parseInt(new URLSearchParams(location.search).get('slide') || '0', 10);
+  
+  function activate() {
+    var slides = document.querySelectorAll('.slide');
+    if (!slides.length) return;
+    idx = Math.max(0, Math.min(idx, slides.length - 1));
+    slides.forEach(function(s, i) {
+      if (i === idx) {
+        s.classList.add('active');
+        s.classList.remove('past');
+      } else {
+        s.classList.remove('active');
+        s.classList.add('past');
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', activate);
+  } else {
+    activate();
+  }
+})();
+</script>`;
+
+  // Inject right before </head>
+  return html.replace('</head>', `${css}\n${script}\n</head>`);
+}
+
+export async function compileToScreenshotPptx(
+  html: string,
+  slideCount: number,
+  outputPath: string,
+  opts: ScreenshotPptxOptions = {}
+): Promise<void> {
+  const chromeBin = opts.chromePath ?? findChromeBinary();
+  if (!chromeBin) {
+    throw new Error(
+      'Screenshot PPTX export requires Google Chrome or Chromium.\n' +
+        '  → Install Chrome/Chromium, or set CHROME_PATH environment variable.'
+    );
+  }
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+  const width = opts.width ?? 1920;
+  const height = opts.height ?? 1080;
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mdslide-pptx-'));
+  const cleanup = () => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {}
+  };
+
+  try {
+    const modifiedHtml = injectSlideSelector(html);
+
+    // Start local HTTP server directly out of system RAM memory
+    const serverPort = await getFreePort();
+    const stopServer = await serveHtml(modifiedHtml, serverPort, opts.baseDir ?? process.cwd());
+    const baseUrl = `http://127.0.0.1:${serverPort}`;
+
+    const pngPaths: string[] = [];
+
+    // Screenshot each slide sequentially to avoid CPU/resource overload
+    for (let i = 0; i < slideCount; i++) {
+      const pngPath = path.join(tmpDir, `slide-${i}.png`);
+      const url = `${baseUrl}/?slide=${i}`;
+      pngPaths.push(pngPath);
+
+      await screenshotSlide(chromeBin, url, pngPath, width, height, timeoutMs);
+    }
+
+    stopServer();
+
+    // Build PPTX with screenshots as full-bleed images
+    const pptx = new (pptxgen as any)();
+    pptx.layout = 'LAYOUT_WIDE';
+
+    for (let i = 0; i < pngPaths.length; i++) {
+      const pngPath = pngPaths[i]!;
+      if (!fs.existsSync(pngPath)) continue;
+
+      const slide = pptx.addSlide();
+      slide.addImage({
+        path: pngPath,
+        x: 0,
+        y: 0,
+        w: '100%',
+        h: '100%',
+      });
+    }
+
+    fs.mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true });
+    await pptx.writeFile({ fileName: path.resolve(outputPath) });
+  } finally {
+    cleanup();
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,30 @@
+import { MdSlideConfig } from './types/index.js';
+export { compileCommand } from './commands/compile.js';
+export { watchCommand } from './commands/watch.js';
+export { initCommand } from './commands/init.js';
+export { validateCommand } from './commands/validate.js';
+export { Logger } from './logger/index.js';
+export { Spinner } from './ui/spinner.js';
+
+export {
+  MdSlideError,
+  InputNotFoundError,
+  InvalidFormatError,
+  ChromeNotFoundError,
+  PortInUseError,
+  CompileError,
+} from './middleware/errors.js';
+
+export type {
+  OutputFormat,
+  LogLevel,
+  CompileOptions,
+  WatchOptions,
+  InitOptions,
+  ValidateOptions,
+  CompileResult,
+} from './types/index.js';
+
+export function defineConfig(config: MdSlideConfig): MdSlideConfig {
+  return config;
+}

--- a/packages/cli/src/interactiveCommands/helper/confirmCommand.ts
+++ b/packages/cli/src/interactiveCommands/helper/confirmCommand.ts
@@ -1,0 +1,56 @@
+import readline from 'readline';
+import { c, showCursor } from './helper.js';
+import { isTTY, COLORS, STYLES } from '../../constants/index.js';
+
+// Conform commands
+async function confirm(prompt: string, def = true): Promise<boolean> {
+  const hint = def ? 'Y/n' : 'y/N';
+  process.stdout.write(
+    `\n  ${c(COLORS.cyan, '?')} ${c(STYLES.bold, prompt)} ${c(COLORS.grey, `(${hint})`)}: `
+  );
+  showCursor();
+
+  return new Promise((resolve) => {
+    if (!isTTY) {
+      resolve(def);
+      return;
+    }
+
+    readline.emitKeypressEvents(process.stdin);
+    process.stdin.setRawMode(true);
+
+    const onKey = (_: any, key: readline.Key) => {
+      if (!key) return;
+      if (key.ctrl && key.name === 'c') {
+        process.exit(130);
+      }
+
+      const ch = key.sequence?.toLowerCase();
+      if (ch === 'y') {
+        process.stdout.write('y\n');
+        done(true);
+        return;
+      }
+      if (ch === 'n') {
+        process.stdout.write('n\n');
+        done(false);
+        return;
+      }
+      if (key.name === 'return' || key.name === 'enter') {
+        process.stdout.write(def ? 'y\n' : 'n\n');
+        done(def);
+        return;
+      }
+    };
+
+    const done = (val: boolean) => {
+      process.stdin.removeListener('keypress', onKey);
+      process.stdin.setRawMode(false);
+      resolve(val);
+    };
+
+    process.stdin.on('keypress', onKey);
+  });
+}
+
+export { confirm };

--- a/packages/cli/src/interactiveCommands/helper/helper.ts
+++ b/packages/cli/src/interactiveCommands/helper/helper.ts
@@ -1,0 +1,27 @@
+import { isTTY } from '../../constants/tellyTypewriter.js';
+import { CURSOR, ERASE, STYLES } from '../../constants/terminalEscapeCode.js';
+
+function c(color: string, text: string) {
+  return isTTY ? `${color}${text}${STYLES.reset}` : text;
+}
+
+function clrLine() {
+  if (isTTY) {
+    // Moves to start, then erases the line contents
+    process.stdout.write(`${CURSOR.carriageReturn}${ERASE.line}`);
+  }
+}
+
+function movUp(n = 1) {
+  if (isTTY) process.stdout.write(CURSOR.up(n));
+}
+
+function hideCursor() {
+  if (isTTY) process.stdout.write(CURSOR.hide);
+}
+
+function showCursor() {
+  if (isTTY) process.stdout.write(CURSOR.show);
+}
+
+export { c, clrLine, movUp, hideCursor, showCursor };

--- a/packages/cli/src/interactiveCommands/helper/index.ts
+++ b/packages/cli/src/interactiveCommands/helper/index.ts
@@ -1,0 +1,4 @@
+export * from './confirmCommand.js';
+export * from './helper.js';
+export * from './inputCommand.js';
+export * from './selectCommand.js';

--- a/packages/cli/src/interactiveCommands/helper/inputCommand.ts
+++ b/packages/cli/src/interactiveCommands/helper/inputCommand.ts
@@ -1,0 +1,55 @@
+import readline from 'readline';
+import { COLORS, STYLES, isTTY } from '../../constants/index.js';
+import { c, clrLine, showCursor } from './helper.js';
+
+// Input as a text
+async function input(prompt: string, defaultVal?: string): Promise<string> {
+  return new Promise((resolve) => {
+    if (!isTTY) {
+      resolve(defaultVal ?? '');
+      return;
+    }
+
+    const def = defaultVal ? c(COLORS.grey, ` (${defaultVal})`) : '';
+    process.stdout.write(`\n  ${c(COLORS.cyan, '?')} ${c(STYLES.bold, prompt)}${def}: `);
+    showCursor();
+
+    let answer = '';
+    readline.emitKeypressEvents(process.stdin);
+    if (process.stdin.isTTY) process.stdin.setRawMode(true);
+
+    const onKey = (_: any, key: readline.Key) => {
+      if (!key) return;
+
+      if (key.ctrl && key.name === 'c') {
+        process.stdin.removeListener('keypress', onKey);
+        if (process.stdin.isTTY) process.stdin.setRawMode(false);
+        process.exit(130);
+      }
+
+      if (key.name === 'return' || key.name === 'enter') {
+        process.stdout.write('\n');
+        process.stdin.removeListener('keypress', onKey);
+        if (process.stdin.isTTY) process.stdin.setRawMode(false);
+        resolve(answer.trim() || defaultVal || '');
+        return;
+      }
+
+      if (key.name === 'backspace') {
+        answer = answer.slice(0, -1);
+        clrLine();
+        process.stdout.write(`  ${c(COLORS.cyan, '?')} ${c(STYLES.bold, prompt)}${def}: ${answer}`);
+        return;
+      }
+
+      if (key.sequence && !key.ctrl && !key.meta) {
+        answer += key.sequence;
+        process.stdout.write(key.sequence);
+      }
+    };
+
+    process.stdin.on('keypress', onKey);
+  });
+}
+
+export { input };

--- a/packages/cli/src/interactiveCommands/helper/selectCommand.ts
+++ b/packages/cli/src/interactiveCommands/helper/selectCommand.ts
@@ -1,0 +1,106 @@
+import readline from 'readline';
+import { COLORS, STYLES, isTTY } from '../../constants/index.js';
+import { Choice } from '../../types/index.js';
+import { c, hideCursor, showCursor } from './helper.js';
+import { icons } from '../../assets/index.js';
+
+// List Selector
+async function select<T>(
+  prompt: string,
+  choices: Choice<T>[],
+  opts: { color?: boolean } = {}
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    if (!isTTY) {
+      // Non-TTY fallback: pick first
+      resolve(choices[0]!.value);
+      return;
+    }
+
+    let idx = 0;
+
+    let renderedLines = 0;
+
+    const render = () => {
+      const lines: string[] = [];
+
+      choices.forEach((ch, i) => {
+        const selected = i === idx;
+        const cursor = selected ? c(COLORS.cyan, icons.navigateArrow) : ' ';
+        const swatch = opts.color && ch.color ? `${ch.color}${icons.info}${STYLES.reset} ` : '';
+
+        const label = selected ? c(STYLES.bold + COLORS.white, ch.label) : c(COLORS.grey, ch.label);
+
+        const hint = ch.hint && selected ? `  ${c(COLORS.grey, ch.hint)}` : '';
+
+        lines.push(`  ${cursor} ${swatch}${label}${hint}`);
+      });
+
+      process.stdout.write(lines.join('\n'));
+      renderedLines = lines.length;
+    };
+
+    const clear = () => {
+      for (let i = 0; i < renderedLines; i++) {
+        process.stdout.write('\r\x1b[2K');
+
+        if (i < renderedLines - 1) {
+          process.stdout.write('\x1b[1A');
+        }
+      }
+
+      process.stdout.write('\r');
+    };
+
+    // Print prompt
+    process.stdout.write(
+      `\n  ${c(COLORS.cyan, '?')} ${c(STYLES.bold, prompt)} ${c(COLORS.grey, '(↑↓ to move, Enter to select)')}\n`
+    );
+
+    hideCursor();
+    render();
+
+    readline.emitKeypressEvents(process.stdin);
+    process.stdin.setRawMode(true);
+
+    const onKey = (_: any, key: readline.Key) => {
+      if (!key) return;
+
+      if (key.name === 'up') {
+        idx = (idx - 1 + choices.length) % choices.length;
+      }
+      if (key.name === 'down') {
+        idx = (idx + 1) % choices.length;
+      }
+
+      if (key.name === 'return' || key.name === 'enter') {
+        clear();
+        process.stdout.write(
+          `  ${c(COLORS.green, '✔')} ${c(STYLES.bold, prompt)}  ${c(COLORS.cyan, String((choices[idx] as any).label))}\n`
+        );
+        cleanup();
+        resolve(choices[idx]!.value);
+        return;
+      }
+
+      if (key.ctrl && key.name === 'c') {
+        cleanup();
+        showCursor();
+        process.exit(130);
+      }
+
+      clear();
+      render();
+    };
+
+    const cleanup = () => {
+      process.stdin.removeListener('keypress', onKey);
+      if (process.stdin.isTTY) process.stdin.setRawMode(false);
+      showCursor();
+    };
+
+    process.stdin.on('keypress', onKey);
+  });
+}
+
+export { select };

--- a/packages/cli/src/interactiveCommands/index.ts
+++ b/packages/cli/src/interactiveCommands/index.ts
@@ -1,0 +1,59 @@
+import path from 'path';
+import fs from 'fs';
+import readline from 'readline';
+import { Logger } from '../logger/index.js';
+import { STYLES, COLORS, ERASE, CURSOR } from '../constants/index.js';
+import { Choice, InteractiveResult } from '../types/index.js';
+import { outputFormat, themeTypes } from '../constants/formats.js';
+import { c } from './helper/helper.js';
+import { confirm, input, select } from './helper/index.js';
+
+// Interactive Prompt FLow Orchastrator
+export async function runInteractivePrompt(inputFile: string): Promise<InteractiveResult> {
+  const log = new Logger('info');
+  const name = path.basename(inputFile);
+
+  log.raw('');
+  log.raw(`  ${c(COLORS.magenta + STYLES.bold, '✦ mdslide')}  ${c(COLORS.grey, `→ ${name}`)}`);
+  log.raw(`  ${c(COLORS.grey, '─'.repeat(40))}`);
+
+  // Outpur Format
+  const format = await select<string>('Output format', outputFormat, { color: true });
+
+  // Themes
+  const theme = await select<string>('Theme', themeTypes, { color: true });
+
+  // output File
+  const defaultOut = `output.${format}`;
+  const output = await input('Output file', defaultOut);
+
+  // watch mode
+  let watch = false;
+  if (format === 'html') {
+    watch = await confirm('Start live-reload watch server?', false);
+  }
+
+  // open after Compilation
+  const open = await confirm('Open after compile?', true);
+
+  // Summary
+  log.raw('');
+  log.raw(`  ${c(COLORS.grey, '─'.repeat(40))}`);
+  log.raw(`  ${c(COLORS.grey, 'format')}  ${c(COLORS.cyan + STYLES.bold, format.toUpperCase())}`);
+  log.raw(`  ${c(COLORS.grey, 'theme ')}  ${c(COLORS.cyan + STYLES.bold, theme)}`);
+  log.raw(`  ${c(COLORS.grey, 'output')}  ${c(COLORS.cyan + STYLES.bold, output)}`);
+  if (format === 'html') {
+    log.raw(`  ${c(COLORS.grey, 'watch ')}  ${c(COLORS.cyan + STYLES.bold, watch ? 'yes' : 'no')}`);
+  }
+  log.raw(`  ${c(COLORS.grey, 'open  ')}  ${c(COLORS.cyan + STYLES.bold, open ? 'yes' : 'no')}`);
+  log.raw('');
+
+  const go = await confirm('Compile now?', true);
+  if (!go) {
+    log.raw(`\n  ${c(COLORS.grey, 'Cancelled.')}\n`);
+    process.exit(0);
+  }
+
+  log.raw('');
+  return { format, theme, output, watch, open };
+}

--- a/packages/cli/src/script/reloadScript.ts
+++ b/packages/cli/src/script/reloadScript.ts
@@ -1,0 +1,10 @@
+// Live Reload script
+export const RELOAD_SCRIPT = `
+<script>
+(function(){
+  const es = new EventSource('/~live-reload');
+  es.onmessage = (e) => { if (e.data === 'reload') location.reload(); };
+  es.onerror   = () => setTimeout(() => location.reload(), 2000);
+})();
+</script>
+`;

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -62,3 +62,17 @@ export interface ValidationIssue {
   message: string;
   hint?: string;
 }
+
+export interface MdSlideConfig {
+  theme?: string;
+  output?: string;
+  format?: string;
+  watch?: {
+    port?: number;
+    open?: boolean;
+  };
+  pdf?: {
+    chromePath?: string;
+    printBackground?: boolean;
+  };
+}

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -1,0 +1,64 @@
+export type OutputFormat = 'html' | 'pdf' | 'pptx';
+
+export type LogLevel = 'silent' | 'info' | 'verbose';
+
+export interface GlobalOptions {
+  logLevel?: LogLevel;
+}
+
+export interface CompileOptions extends GlobalOptions {
+  theme?: string;
+  output?: string;
+  format?: OutputFormat;
+  open?: boolean;
+  strict?: boolean;
+}
+
+export interface WatchOptions extends GlobalOptions {
+  theme?: string;
+  output?: string;
+  port?: number;
+  open?: boolean;
+}
+
+export interface ServeOptions extends GlobalOptions {
+  port?: number;
+  open?: boolean;
+}
+
+export interface InitOptions extends GlobalOptions {
+  force?: boolean;
+}
+
+export interface ValidateOptions extends GlobalOptions {
+  strict?: boolean;
+}
+
+export interface CompileResult {
+  outputPath: string;
+  format: OutputFormat;
+  slideCount: number;
+  warnings: string[];
+}
+
+export interface Choice<T = string> {
+  label: string;
+  value: T;
+  hint?: string;
+  color?: string; // ansi color for the label swatch
+}
+
+export interface InteractiveResult {
+  format: string;
+  theme: string;
+  output: string;
+  watch: boolean;
+  open: boolean;
+}
+
+export interface ValidationIssue {
+  type: 'error' | 'warning';
+  slide?: number;
+  message: string;
+  hint?: string;
+}

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -1,3 +1,4 @@
+import { icons } from '../assets/index.js';
 import { STYLES, COLORS } from '../constants/index.js';
 
 export function c(color: string, text: string): string {
@@ -5,11 +6,16 @@ export function c(color: string, text: string): string {
   return `${color}${text}${STYLES.reset}`;
 }
 
+export function link(url: string): string {
+  if (!process.stdout.isTTY) return url;
+  return `${COLORS.cyan}${STYLES.bold}${url}${STYLES.reset}`;
+}
+
 export const ICONS = {
-  info: c(COLORS.blue, '●'),
-  success: c(COLORS.green, '✔'),
-  warn: c(COLORS.yellow, '⚠'),
-  error: c(COLORS.red, '✖'),
-  step: c(COLORS.cyan, '→'),
-  dim: c(COLORS.grey, '·'),
+  info: c(COLORS.blue, icons.info),
+  success: c(COLORS.green, icons.succcess),
+  warn: c(COLORS.yellow, icons.warning),
+  error: c(COLORS.red, icons.cross),
+  step: c(COLORS.cyan, icons.rightArrow),
+  dim: c(COLORS.grey, icons.dim),
 };

--- a/packages/core/src/renderer/html/index.ts
+++ b/packages/core/src/renderer/html/index.ts
@@ -80,6 +80,44 @@ export function renderDeck(deck: SlideDeck, options: RenderDeckOptions = {}): st
     [data-theme="gradient"] .line-numbers-rows {
       border-right: 1px solid rgba(255,255,255,0.15) !important;
     }
+
+    @media print {
+      @page {
+        size: 1920px 1080px;
+        margin: 0;
+      }
+      body {
+        background: var(--slide-bg) !important;
+        color: var(--slide-text) !important;
+        -webkit-print-color-adjust: exact !important;
+        print-color-adjust: exact !important;
+        overflow: visible !important;
+        height: auto !important;
+      }
+      .deck {
+        height: auto !important;
+        overflow: visible !important;
+      }
+      .slide {
+        position: relative !important;
+        display: flex !important;
+        opacity: 1 !important;
+        pointer-events: auto !important;
+        transform: none !important;
+        page-break-after: always !important;
+        break-after: page !important;
+        height: 1080px !important;
+        width: 1920px !important;
+        box-shadow: none !important;
+        margin: 0 !important;
+        border: none !important;
+        float: none !important;
+      }
+      .dokContainer,
+      .progressBarContainer {
+        display: none !important;
+      }
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Screenshort based pptx exporter
add screenshot-based PPTX export

Introduce a CLI command to export HTML presentations into PPTX format
by capturing screenshots using an in-memory headless browser.

- Find an available local port dynamically.
- Spawn a thread to serve the HTML content from memory.
- Inject custom styles and scripts to disable animations.
- Capture individual slide screenshots using Chromium's print module.

## pptgex editable pptx exporter
add direct slide-based AST to PptxGenJS exporter

Introduce a direct PPTX exporter command in the CLI that parses the slide 
markdown AST and maps layouts directly into PowerPoint slide schemas.

- Support Main Title layouts.
- Support Title with Children layout hierarchies.
- Support Statement and Blockquote styles.
- Implement Code, Visual, and Table layout renderers.
- Implement Custom Split and Bullets/Content layouts.