### PR TITLE
Feat/mermaid diagram rendering support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .DS_Store
 .env
 coverage
+.turbo

--- a/bun.lock
+++ b/bun.lock
@@ -49,9 +49,11 @@
         "@mindfiredigital/mdslide-parser": "workspace:*",
         "@mindfiredigital/mdslide-shared": "workspace:*",
         "gray-matter": "^4.0.3",
+        "katex": "^0.16.9",
         "mdast-util-to-string": "^4.0.0",
       },
       "devDependencies": {
+        "@types/katex": "^0.16.7",
         "@types/mdast": "^4.0.4",
         "@types/node": "^25.6.0",
         "tsup": "^8.0.0",
@@ -65,6 +67,7 @@
       },
       "dependencies": {
         "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0",
         "remark-parse": "^11.0.0",
         "unified": "^11.0.5",
       },
@@ -410,7 +413,11 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/katex": ["@types/katex@0.16.8", "", {}, "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
@@ -898,6 +905,8 @@
 
     "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
 
+    "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
@@ -982,6 +991,8 @@
 
     "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
 
+    "mdast-util-math": ["mdast-util-math@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "longest-streak": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.1.0", "unist-util-remove-position": "^5.0.0" } }, "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w=="],
+
     "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
 
     "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
@@ -1011,6 +1022,8 @@
     "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
 
     "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-extension-math": ["micromark-extension-math@3.1.0", "", { "dependencies": { "@types/katex": "^0.16.0", "devlop": "^1.0.0", "katex": "^0.16.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg=="],
 
     "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
 
@@ -1174,6 +1187,8 @@
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
+    "remark-math": ["remark-math@6.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-math": "^3.0.0", "micromark-extension-math": "^3.0.0", "unified": "^11.0.0" } }, "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA=="],
+
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
@@ -1328,6 +1343,8 @@
 
     "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 
+    "unist-util-remove-position": ["unist-util-remove-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q=="],
+
     "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
 
     "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
@@ -1447,6 +1464,8 @@
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "lint-staged/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "prettier": "^3.8.1",
         "start-server-and-test": "^3.0.11",
         "tsup": "^8.5.1",
+        "turbo": "^2.9.18",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.57.1",
         "vitest": "^4.1.0",
@@ -384,6 +385,18 @@
     "@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.2.0", "", {}, "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.18", "", { "os": "darwin", "cpu": "x64" }, "sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw=="],
+
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.18", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ=="],
+
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.18", "", { "os": "linux", "cpu": "x64" }, "sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw=="],
+
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg=="],
+
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.18", "", { "os": "win32", "cpu": "x64" }, "sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw=="],
+
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.18", "", { "os": "win32", "cpu": "arm64" }, "sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
@@ -1294,6 +1307,8 @@
     "tsup": ["tsup@8.5.1", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.27.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "^0.7.6", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
+
+    "turbo": ["turbo@2.9.18", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.18", "@turbo/darwin-arm64": "2.9.18", "@turbo/linux-64": "2.9.18", "@turbo/linux-arm64": "2.9.18", "@turbo/windows-64": "2.9.18", "@turbo/windows-arm64": "2.9.18" }, "bin": { "turbo": "bin/turbo" } }, "sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg=="],
 
     "tweetnacl": ["tweetnacl@0.14.5", "", {}, "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="],
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "bun@1.2.23",
   "scripts": {
-    "build": "bun run --filter ./packages/shared build && bun run --filter ./packages/parser build && bun run --filter ./packages/core build &&bun run --filter ./packages/cli build",
+    "build": "turbo run build",
     "dev": "bun run --filter \"*\" dev",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -17,7 +17,8 @@
     "e2e:run": "start-server-and-test 'bun packages/cli/dist/cli.js watch presentation-e2e.md --port 3030' http://localhost:3030 'cypress run'",
     "e2e:open": "start-server-and-test 'bun packages/cli/dist/cli.js watch presentation-e2e.md --port 3030' http://localhost:3030 'cypress open'",
     "version": "changeset version",
-    "release": "changeset publish"
+    "release": "bun run build && changeset publish",
+    "changeset": "changeset"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
@@ -33,6 +34,7 @@
     "prettier": "^3.8.1",
     "start-server-and-test": "^3.0.11",
     "tsup": "^8.5.1",
+    "turbo": "^2.9.18",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.1",
     "vitest": "^4.1.0"

--- a/packages/cli/src/constants/logs/validationCommandLogs.ts
+++ b/packages/cli/src/constants/logs/validationCommandLogs.ts
@@ -44,6 +44,7 @@ export const SUPPORTED_LANGS = [
   'sql',
   'yaml',
   'yml',
+  'mermaid',
 ] as const;
 
 export const VALIDATION_MESSAGES = {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,9 +24,11 @@
     "@mindfiredigital/mdslide-parser": "workspace:*",
     "@mindfiredigital/mdslide-shared": "workspace:*",
     "gray-matter": "^4.0.3",
+    "katex": "^0.16.9",
     "mdast-util-to-string": "^4.0.0"
   },
   "devDependencies": {
+    "@types/katex": "^0.16.7",
     "@types/mdast": "^4.0.4",
     "@types/node": "^25.6.0",
     "tsup": "^8.0.0"

--- a/packages/core/src/ast/createSlideNode.ts
+++ b/packages/core/src/ast/createSlideNode.ts
@@ -23,5 +23,6 @@ export function createSlide(partial: Partial<Slide>): Slide {
     notes: partial.notes,
     title: partial.title,
     layoutOverride: partial.layoutOverride,
+    backgroundImage: partial.backgroundImage,
   };
 }

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -40,6 +40,7 @@ export const SUPPORTED_LANGS = [
   'sql',
   'yaml',
   'yml',
+  'mermaid',
 ];
 
 export const DEFAULT_TITLE = 'Presentation';

--- a/packages/core/src/overflow/index.ts
+++ b/packages/core/src/overflow/index.ts
@@ -80,6 +80,7 @@ export function processOverflow(slides: Slide[]): Slide[] {
         content: currentSlideContent,
         notes: isContinuation ? undefined : slide.notes,
         layoutOverride: slide.layoutOverride,
+        backgroundImage: slide.backgroundImage,
       });
 
       continuationCount++;
@@ -99,7 +100,7 @@ export function processOverflow(slides: Slide[]): Slide[] {
           continue;
         }
 
-        if (node.type === 'code' && availableHeight > 100) {
+        if (node.type === 'code' && node.lang !== 'mermaid' && availableHeight > 100) {
           const lines = (node.value || '').split('\n');
           const maxLines = Math.floor((availableHeight - 40) / 16);
 
@@ -184,6 +185,7 @@ export function processOverflow(slides: Slide[]): Slide[] {
         content: currentSlideContent,
         notes: isContinuation ? undefined : slide.notes,
         layoutOverride: slide.layoutOverride,
+        backgroundImage: slide.backgroundImage,
       });
     }
   }

--- a/packages/core/src/renderer/html/index.ts
+++ b/packages/core/src/renderer/html/index.ts
@@ -82,6 +82,22 @@ export function renderDeck(deck: SlideDeck, options: RenderDeckOptions = {}): st
       border-right: 1px solid rgba(255,255,255,0.15) !important;
     }
 
+    .mermaid {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 100%;
+      margin: 1.5rem 0;
+      background: transparent !important;
+    }
+
+    .mermaid svg {
+      max-width: 100% !important;
+      max-height: 55vh !important;
+      height: auto !important;
+    }
+
+    
     @media print {
       @page {
         size: 1920px 1080px;
@@ -153,6 +169,17 @@ ${slidesHtml}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+  <!-- Mermaid Support -->
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+    mermaid.initialize({
+      startOnLoad: true,
+      theme: document.documentElement.getAttribute('data-theme') === 'dark' || 
+             document.documentElement.getAttribute('data-theme') === 'terminal' ||
+             document.documentElement.getAttribute('data-theme') === 'gradient'
+             ? 'dark' : 'default'
+    });
+  </script>
   ${script}
 </body>
 </html>`;

--- a/packages/core/src/renderer/html/index.ts
+++ b/packages/core/src/renderer/html/index.ts
@@ -29,6 +29,7 @@ export function renderDeck(deck: SlideDeck, options: RenderDeckOptions = {}): st
   <style id="mdslideTheme">${themeEngine.resolveTheme(theme)}</style>
   <link rel="stylesheet" href="${prismThemeUrl}" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.9/katex.min.css" />
   <style>
     /* Custom Prism overrides to match slide styling perfectly */
     pre[class*="language-"] {

--- a/packages/core/src/renderer/html/renderCode.ts
+++ b/packages/core/src/renderer/html/renderCode.ts
@@ -6,6 +6,10 @@ export function renderCodeBlock(node: SlideNode): string {
   const lang = (node.lang ?? '').toLowerCase();
   const value = node.value ?? '';
 
+  if (lang === 'mermaid') {
+    return `<div class="mermaid">${sanitizeHtml(value)}</div>`;
+  }
+
   if (lang && SUPPORTED_LANGS.includes(lang)) {
     return `<pre class="lineNumbers language-${sanitizeHtml(lang)}"><code class="language-${sanitizeHtml(lang)}">${sanitizeHtml(value)}</code></pre>`;
   }

--- a/packages/core/src/renderer/html/renderSlide.ts
+++ b/packages/core/src/renderer/html/renderSlide.ts
@@ -177,10 +177,10 @@ export function nodeToHtml(node: SlideNode): string {
       return '';
 
     case 'math':
-      return `<div class="math math-display">${renderMath(node.value ?? '', true)}</div>`;
+      return `<div class="math mathDisplay">${renderMath(node.value ?? '', true)}</div>`;
 
     case 'inlineMath':
-      return `<span class="math math-inline">${renderMath(node.value ?? '', false)}</span>`;
+      return `<span class="math mathInline">${renderMath(node.value ?? '', false)}</span>`;
 
     case 'column':
       return childrenToHtml(node);

--- a/packages/core/src/renderer/html/renderSlide.ts
+++ b/packages/core/src/renderer/html/renderSlide.ts
@@ -1,7 +1,19 @@
 import type { Slide, SlideNode } from '@mindfiredigital/mdslide-shared';
+import katex from 'katex';
 import { renderCodeBlock, renderInlineCode } from './renderCode.js';
 import { renderTable, renderTableRow, renderTableCell } from './renderTable.js';
 import { sanitizeHtml, sanitizeUrl } from '../../utils/index.js';
+
+function renderMath(formula: string, displayMode: boolean): string {
+  try {
+    return katex.renderToString(formula, {
+      displayMode,
+      throwOnError: false,
+    });
+  } catch (err) {
+    return sanitizeHtml(formula);
+  }
+}
 
 // Extract all image node from tree and return them separately
 function extractImages(nodes: SlideNode[]): {
@@ -164,6 +176,12 @@ export function nodeToHtml(node: SlideNode): string {
       // Strip HTML comments and raw HTML nodes
       return '';
 
+    case 'math':
+      return `<div class="math math-display">${renderMath(node.value ?? '', true)}</div>`;
+
+    case 'inlineMath':
+      return `<span class="math math-inline">${renderMath(node.value ?? '', false)}</span>`;
+
     case 'column':
       return childrenToHtml(node);
 
@@ -254,7 +272,15 @@ export function renderSlide(slide: Slide): string {
     contentHtml = slide.content.map(nodeToHtml).join('\n');
   }
 
-  return `<section class="slide" data-type="${slide.type}" data-id="${slide.id}">
+  let bgAttr = '';
+  let bgStyle = '';
+  if (slide.backgroundImage) {
+    const cleanUrl = slide.backgroundImage.replace(/\s+(dark|light)$/i, '').trim();
+    bgAttr = ` data-background-image="${sanitizeHtml(slide.backgroundImage)}"`;
+    bgStyle = ` style="background-image: url('${sanitizeHtml(cleanUrl)}') !important; background-size: cover !important; background-position: center !important; background-repeat: no-repeat !important;"`;
+  }
+
+  return `<section class="slide"${bgAttr}${bgStyle} data-type="${slide.type}" data-id="${slide.id}">
   ${titleHtml}
   <div class="slideContent">
     ${contentHtml}

--- a/packages/core/tests/overflow.test.ts
+++ b/packages/core/tests/overflow.test.ts
@@ -9,7 +9,10 @@ describe('Overflow Engine', () => {
       id: 'slide-1',
       title: 'Short Slide',
       content: [
-        createSlideNode({ type: 'paragraph', children: [createSlideNode({ type: 'text', value: 'Hello' })] }),
+        createSlideNode({
+          type: 'paragraph',
+          children: [createSlideNode({ type: 'text', value: 'Hello' })],
+        }),
       ],
     });
 
@@ -46,12 +49,14 @@ describe('Overflow Engine', () => {
   test('splits long list when height budget is exceeded', () => {
     // List item base height = max(22, wrapLines * 20)
     // 35 items of ~25px each = ~875px, which is > 650px.
-    const listItems = Array(35).fill(null).map((_, i) =>
-      createSlideNode({
-        type: 'listItem',
-        children: [createSlideNode({ type: 'text', value: `List item number ${i}` })],
-      })
-    );
+    const listItems = Array(35)
+      .fill(null)
+      .map((_, i) =>
+        createSlideNode({
+          type: 'listItem',
+          children: [createSlideNode({ type: 'text', value: `List item number ${i}` })],
+        })
+      );
 
     const slide = createSlide({
       id: 'slide-list',
@@ -75,12 +80,19 @@ describe('Overflow Engine', () => {
   test('splits general flat content slide when height budget is exceeded', () => {
     // 30 paragraph nodes. Each paragraph = ~28px.
     // 30 * 28 = 840px > 650px.
-    const paragraphs = Array(30).fill(null).map((_, i) =>
-      createSlideNode({
-        type: 'paragraph',
-        children: [createSlideNode({ type: 'text', value: `This is paragraph number ${i} which has some content text.` })],
-      })
-    );
+    const paragraphs = Array(30)
+      .fill(null)
+      .map((_, i) =>
+        createSlideNode({
+          type: 'paragraph',
+          children: [
+            createSlideNode({
+              type: 'text',
+              value: `This is paragraph number ${i} which has some content text.`,
+            }),
+          ],
+        })
+      );
 
     const slide = createSlide({
       id: 'slide-paragraphs',
@@ -93,5 +105,25 @@ describe('Overflow Engine', () => {
     expect(result[0].id).toBe('slide-paragraphs');
     expect(result[1].id).toBe('slide-paragraphs-cont-p1');
     expect(result[1].title).toBe('Long Paragraphs (Cont.)');
+  });
+
+  test('does not split code block if it is a mermaid diagram', () => {
+    const lines = Array(45).fill('A --> B').join('\n');
+    const slide = createSlide({
+      id: 'slide-mermaid',
+      title: 'Mermaid Diagram',
+      content: [
+        createSlideNode({
+          type: 'code',
+          lang: 'mermaid',
+          value: lines,
+        }),
+      ],
+    });
+
+    const result = processOverflow([slide]);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toHaveLength(1);
+    expect(result[0].content[0].value).toBe(lines);
   });
 });

--- a/packages/core/tests/renderer.test.ts
+++ b/packages/core/tests/renderer.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect } from 'vitest';
-import { renderDeck, renderSlide, nodeToHtml, childrenToHtml, renderListItemText } from '../src/renderer/html/index.ts';
+import {
+  renderDeck,
+  renderSlide,
+  nodeToHtml,
+  childrenToHtml,
+  renderListItemText,
+} from '../src/renderer/html/index.ts';
 import { renderCodeBlock, renderInlineCode } from '../src/renderer/html/renderCode.ts';
 import { renderTable, renderTableRow, renderTableCell } from '../src/renderer/html/renderTable.ts';
 import { createSlide, createSlideNode } from '../src/ast/createSlideNode.ts';
@@ -7,7 +13,9 @@ import { sanitizeHtml } from '../src/utils/html.ts';
 
 describe('HTML Sanitization', () => {
   test('escapes HTML special characters', () => {
-    expect(sanitizeHtml('<div>Hello & Welcome</div>')).toBe('&lt;div&gt;Hello &amp; Welcome&lt;/div&gt;');
+    expect(sanitizeHtml('<div>Hello & Welcome</div>')).toBe(
+      '&lt;div&gt;Hello &amp; Welcome&lt;/div&gt;'
+    );
   });
 });
 
@@ -80,7 +88,9 @@ describe('Node and Children Renderer', () => {
 
   test('renderCodeBlock generates styled blocks', () => {
     const tsNode = createSlideNode({ type: 'code', lang: 'typescript', value: 'const a = 1;' });
-    expect(renderCodeBlock(tsNode)).toBe('<pre class="lineNumbers language-typescript"><code class="language-typescript">const a = 1;</code></pre>');
+    expect(renderCodeBlock(tsNode)).toBe(
+      '<pre class="lineNumbers language-typescript"><code class="language-typescript">const a = 1;</code></pre>'
+    );
 
     const rawNode = createSlideNode({ type: 'code', value: 'raw code' });
     expect(renderCodeBlock(rawNode)).toBe('<pre><code>raw code</code></pre>');
@@ -90,10 +100,18 @@ describe('Node and Children Renderer', () => {
   });
 
   test('renderTable renders table components', () => {
-    const thNode = createSlideNode({ type: 'tableCell', header: true, children: [createSlideNode({ type: 'text', value: 'head' })] });
+    const thNode = createSlideNode({
+      type: 'tableCell',
+      header: true,
+      children: [createSlideNode({ type: 'text', value: 'head' })],
+    });
     expect(renderTableCell(thNode, childrenToHtml)).toBe('<th>head</th>');
 
-    const tdNode = createSlideNode({ type: 'tableCell', header: false, children: [createSlideNode({ type: 'text', value: 'data' })] });
+    const tdNode = createSlideNode({
+      type: 'tableCell',
+      header: false,
+      children: [createSlideNode({ type: 'text', value: 'data' })],
+    });
     expect(renderTableCell(tdNode, childrenToHtml)).toBe('<td>data</td>');
 
     const trNode = createSlideNode({ type: 'tableRow', children: [tdNode] });
@@ -111,7 +129,10 @@ describe('Slide and Deck Renderer', () => {
       type: 'content',
       title: 'Slide Title',
       content: [
-        createSlideNode({ type: 'paragraph', children: [createSlideNode({ type: 'text', value: 'Body content' })] }),
+        createSlideNode({
+          type: 'paragraph',
+          children: [createSlideNode({ type: 'text', value: 'Body content' })],
+        }),
       ],
       notes: 'Speaker Note',
     });
@@ -129,8 +150,14 @@ describe('Slide and Deck Renderer', () => {
       id: 'slide-split',
       type: 'split',
       content: [
-        createSlideNode({ type: 'column', children: [createSlideNode({ type: 'text', value: 'Left Column' })] }),
-        createSlideNode({ type: 'column', children: [createSlideNode({ type: 'text', value: 'Right Column' })] }),
+        createSlideNode({
+          type: 'column',
+          children: [createSlideNode({ type: 'text', value: 'Left Column' })],
+        }),
+        createSlideNode({
+          type: 'column',
+          children: [createSlideNode({ type: 'text', value: 'Right Column' })],
+        }),
       ],
     });
 
@@ -145,7 +172,10 @@ describe('Slide and Deck Renderer', () => {
       id: 'slide-auto-split',
       type: 'split',
       content: [
-        createSlideNode({ type: 'paragraph', children: [createSlideNode({ type: 'text', value: 'Text explanation' })] }),
+        createSlideNode({
+          type: 'paragraph',
+          children: [createSlideNode({ type: 'text', value: 'Text explanation' })],
+        }),
         createSlideNode({ type: 'image', url: 'logo.png', alt: 'Logo' }),
       ],
     });
@@ -182,10 +212,12 @@ describe('Slide and Deck Renderer', () => {
   test('renderListItemText handles different node types', () => {
     // image node -> ''
     expect(renderListItemText(createSlideNode({ type: 'image', url: 'foo.png' }))).toBe('');
-    
+
     // text node -> escaped value
-    expect(renderListItemText(createSlideNode({ type: 'text', value: 'hello <world>' }))).toBe('hello &lt;world&gt;');
-    
+    expect(renderListItemText(createSlideNode({ type: 'text', value: 'hello <world>' }))).toBe(
+      'hello &lt;world&gt;'
+    );
+
     // children nodes -> join
     const parent = createSlideNode({
       type: 'listItem',
@@ -249,7 +281,11 @@ describe('Slide and Deck Renderer', () => {
         createSlideNode({
           type: 'tableRow',
           children: [
-            createSlideNode({ type: 'tableCell', header: true, children: [createSlideNode({ type: 'text', value: 'H1' })] }),
+            createSlideNode({
+              type: 'tableCell',
+              header: true,
+              children: [createSlideNode({ type: 'text', value: 'H1' })],
+            }),
           ],
         }),
       ],
@@ -288,5 +324,23 @@ describe('Slide and Deck Renderer', () => {
     expect(html).not.toContain('<div class="splitLayout">');
     expect(html).toContain('img1.png');
     expect(html).toContain('img2.png');
+  });
+
+  test('nodeToHtml renders math and inlineMath nodes using KaTeX', () => {
+    const inlineMath = createSlideNode({ type: 'inlineMath' as any, value: 'c^2 = a^2 + b^2' });
+    const htmlInline = nodeToHtml(inlineMath);
+    expect(htmlInline).toContain('class="math math-inline"');
+    expect(htmlInline).toContain('katex');
+
+    const blockMath = createSlideNode({ type: 'math' as any, value: '\\sum_{i=1}^n i' });
+    const htmlBlock = nodeToHtml(blockMath);
+    expect(htmlBlock).toContain('class="math math-display"');
+    expect(htmlBlock).toContain('katex-display');
+  });
+
+  test('nodeToHtml renders mermaid code block as div with class mermaid', () => {
+    const node = createSlideNode({ type: 'code', lang: 'mermaid', value: 'graph TD\nA --> B' });
+    const html = nodeToHtml(node);
+    expect(html).toBe('<div class="mermaid">graph TD\nA --&gt; B</div>');
   });
 });

--- a/packages/core/tests/renderer.test.ts
+++ b/packages/core/tests/renderer.test.ts
@@ -329,12 +329,12 @@ describe('Slide and Deck Renderer', () => {
   test('nodeToHtml renders math and inlineMath nodes using KaTeX', () => {
     const inlineMath = createSlideNode({ type: 'inlineMath' as any, value: 'c^2 = a^2 + b^2' });
     const htmlInline = nodeToHtml(inlineMath);
-    expect(htmlInline).toContain('class="math math-inline"');
+    expect(htmlInline).toContain('class="math mathInline"');
     expect(htmlInline).toContain('katex');
 
     const blockMath = createSlideNode({ type: 'math' as any, value: '\\sum_{i=1}^n i' });
     const htmlBlock = nodeToHtml(blockMath);
-    expect(htmlBlock).toContain('class="math math-display"');
+    expect(htmlBlock).toContain('class="math mathDisplay"');
     expect(htmlBlock).toContain('katex-display');
   });
 

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.5"
   },

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -1,6 +1,7 @@
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
 import type { Root } from 'mdast';
 
 export type ParsedAST = Root & {
@@ -39,7 +40,7 @@ export function stripPositions(node: any): any {
 }
 
 export function parseMarkdownToAST(markdown: string, options?: { clean?: boolean }): ParsedAST {
-  const root = unified().use(remarkParse).use(remarkGfm).parse(markdown) as Root;
+  const root = unified().use(remarkParse).use(remarkGfm).use(remarkMath).parse(markdown) as Root;
 
   // Define clean method on standard Root
   Object.defineProperty(root, 'clean', {

--- a/packages/parser/tests/parser.test.ts
+++ b/packages/parser/tests/parser.test.ts
@@ -49,6 +49,33 @@ This is a paragraph.
     expect((table as any).children).toHaveLength(2); // header row + body row
   });
 
+  test('parses markdown math features (like inline and block math)', () => {
+    const md = `
+Inline math: $E = mc^2$
+
+Block math:
+$$
+a^2 + b^2 = c^2
+$$
+    `;
+    const ast = parseMarkdownToAST(md);
+
+    let inlineMathNode: any = null;
+    let mathNode: any = null;
+
+    function walk(node: any) {
+      if (node.type === 'inlineMath') inlineMathNode = node;
+      if (node.type === 'math') mathNode = node;
+      if (node.children) node.children.forEach(walk);
+    }
+    ast.children.forEach(walk);
+
+    expect(inlineMathNode).not.toBeNull();
+    expect(inlineMathNode.value).toBe('E = mc^2');
+    expect(mathNode).not.toBeNull();
+    expect(mathNode.value.trim()).toBe('a^2 + b^2 = c^2');
+  });
+
   describe('Clean AST Options and Chaining', () => {
     const md = '# Hello World\nParagraph content.';
 

--- a/packages/shared/src/types/types.ts
+++ b/packages/shared/src/types/types.ts
@@ -27,6 +27,7 @@ export interface Slide {
   content: SlideNode[];
   notes?: string;
   layoutOverride?: string;
+  backgroundImage?: string;
 }
 
 export interface SlideDeck {

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces Mermaid.js integration, enabling users to embed diagrams directly within Markdown slides using fenced `mermaid` code blocks.

## Changes

### Configuration

* Added `mermaid` to the list of supported visual languages.
* Updated validation rules to allow Mermaid code blocks.

### Rendering

* Added specialized rendering for Mermaid blocks using `<div class="mermaid">`.
* Prevented Mermaid blocks from being rendered as standard syntax-highlighted code.
* Injected Mermaid.js scripts and initialization logic into generated HTML.
* Added SVG height constraints to prevent diagrams from overflowing slides.

### Overflow Handling

* Updated slide overflow processing to treat Mermaid diagrams as atomic nodes.
* Prevented diagrams from being split across multiple slides.

### Tests

* Added renderer tests verifying Mermaid HTML output.
* Verified Mermaid blocks render correctly in generated slides.

## Example

````md
```mermaid
flowchart LR
    A --> B
    B --> C
```
````

Result:

* Mermaid diagrams render automatically in generated presentations.
* Diagrams remain visually intact during slide splitting and pagination.


#85 
