### PR TITLE
clip slide overflow by default with opt-in auto-splitting

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,183 @@
+# ---------------------------------------------------------------------------
+# CodeRabbit Configuration for mindfiredigital/mdslide
+#
+# Stack   : Bun + TypeScript + TSup + Vitest + Cypress
+# Tooling : Bun Workspaces + Turborepo + ESLint + Prettier + Changesets
+# Pattern : Monorepo with parser, core, cli, and shared packages
+#
+# Validate : https://docs.coderabbit.ai/configuration/yaml-validator
+# Reference: https://docs.coderabbit.ai/reference/configuration
+# ---------------------------------------------------------------------------
+
+language: 'en-US'
+
+tone_instructions: 'Senior Node/TypeScript reviewer. Be concise. Prioritise monorepo boundaries, Node/CLI process spawning, browser automation (headless chrome for PDF/PPTX), markdown rendering & AST parsing safety, local HTTP server security, test coverage, and Turborepo setup. Flag real architectural risks; suggest concrete code improvements.'
+
+early_access: false
+
+reviews:
+  profile: 'assertive'
+  request_changes_workflow: true
+
+  high_level_summary: true
+  high_level_summary_instructions: >
+    Summarise the PR in concise bullets grouped by:
+    CLI, Core rendering engine, Parser, Shared packages, Tests (Vitest & Cypress),
+    and Tooling/CI. End with "Breaking changes: None" unless a CLI command,
+    output format, or programmatic API changes.
+  high_level_summary_in_walkthrough: false
+
+  collapse_walkthrough: false
+  changed_files_summary: true
+  sequence_diagrams: true
+  estimate_code_review_effort: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+
+  suggested_labels: true
+  auto_apply_labels: false
+  suggested_reviewers: true
+  auto_assign_reviewers: false
+
+  commit_status: true
+  fail_commit_status: false
+  review_status: true
+  review_details: true
+
+  poem: false
+  in_progress_fortune: false
+
+  auto_review:
+    enabled: true
+    base_branches:
+      - main
+      - dev
+
+  path_filters:
+    - '!dist/**'
+    - '!coverage/**'
+    - '!node_modules/**'
+    - '!bun.lock'
+    - '!**/*.snap'
+    - '!**/__snapshots__/**'
+    - '!**/*.{png,jpg,jpeg,gif,webp,ico,zip}'
+
+  path_instructions:
+    - path: 'packages/cli/src/**/*.ts'
+      instructions: |
+        Review as CLI utility code.
+        - CLI parsing (cac) options must stay clean, robust, and correctly typed.
+        - Process spawning (headless Chrome for PDF/PPTX) must handle shell command injection, proper exit codes, and process cleanup on timeout/failure.
+        - Local preview server (watch command) must secure port bindings, dispose of listeners, and avoid memory leaks.
+        - Directory/file creation and path resolution must prevent directory traversal (e.g. resolve output paths safely).
+
+    - path: 'packages/core/src/**/*.ts'
+      instructions: |
+        Review as core slide compilation code.
+        - Base CSS and themeEngine template overrides must be clean and responsive.
+        - Math typesetting (KaTeX) rendering must handle rendering errors gracefully without crashing the compiler.
+        - HTML sanitization (sanitizeHtml/sanitizeUrl) must block script injection (javascript: URLs, inline event handlers).
+
+    - path: 'packages/parser/src/**/*.ts'
+      instructions: |
+        Review as slide Markdown parser code.
+        - Markdown AST parsing and node transformations should be deterministic.
+        - Handle invalid or malformed slide syntax gracefully, generating helpful warnings/errors instead of throwing.
+        - Handle edge cases in layout metadata parsed from markdown.
+
+    - path: 'packages/shared/src/**/*.ts'
+      instructions: |
+        Review shared packages definitions and types.
+        - Types, interfaces, and contracts must remain robust and backwards-compatible.
+        - Check for precise types rather than arbitrary any/object.
+
+    - path: 'packages/cli/tests/**/*.ts'
+      instructions: |
+        Review CLI unit tests (Vitest).
+        - Test coverage must verify success and error flows (especially parser, CLI commands, and themes).
+        - Spawning/API calls (like Chrome or server listens) should be properly mocked to keep tests fast and platform-independent.
+        - Use clean teardown to prevent side effects in the filesystem.
+
+    - path: 'cypress/**/*.ts'
+      instructions: |
+        Review E2E tests (Cypress).
+        - Check slide interaction, page navigation, fullscreen triggers, and rendering assertions.
+        - Avoid fragile selectors; prefer test-specific attributes or robust text matchers.
+
+    - path: '.github/workflows/**/*.yml'
+      instructions: |
+        Review CI/CD.
+        - Actions should use version tags, not @main.
+        - Secrets must use ${{ secrets.* }} and never be hardcoded.
+        - CI should install with pinned Bun, then run lint, typecheck, tests, and build.
+
+    - path: 'tsup.config.*'
+      instructions: |
+        Review bundle config.
+        - Entries must stay separated.
+        - Externalize dependencies correctly (Node / internal workspaces packages).
+        - Source map settings must be intentional.
+
+    - path: '**/package.json'
+      instructions: |
+        Review package-level scripts and dependencies.
+        - Ensure correct categorization (dependencies vs devDependencies).
+        - Avoid mixing imports across packages without declaring them in package dependencies.
+        - Script updates must stay compatible with Bun workspace syntax.
+
+    - path: 'tsconfig*.json'
+      instructions: |
+        Review TypeScript configs.
+        - Keep strict type safety enabled.
+        - Module, target, moduleResolution, paths, and includes must match workspaces boundaries.
+
+    - path: 'eslint.config.*'
+      instructions: |
+        Review lint config.
+        - TS/JS parsing should cover all workspace packages correctly.
+        - Avoid disabling rules that hide runtime errors or weaken type safety.
+
+  tools:
+    eslint:
+      enabled: true
+    markdownlint:
+      enabled: true
+    actionlint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    htmlhint:
+      enabled: true
+    checkov:
+      enabled: true
+    languagetool:
+      enabled: true
+      enabled_rules:
+        - 'OXFORD_COMMA'
+        - 'EN_QUOTES'
+        - 'COMMA_PARENTHESIS_WHITESPACE'
+      disabled_categories:
+        - 'TYPOGRAPHY'
+    yamllint:
+      enabled: true
+    ast-grep:
+      essential_rules: true
+    biome:
+      enabled: false
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  opt_out: false
+  web_search:
+    enabled: true
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'SECURITY.md'
+  learnings:
+    scope: auto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .DS_Store
 .env
 coverage
+.turbo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# mdslide
+
+`mdslide` is a modular, high-performance monorepo compiler and presentation tool that converts Markdown documents into gorgeous interactive slide decks in HTML, PDF, or editable/screenshot PPTX formats.
+
+---
+
+## 📦 Project Structure
+
+The project is structured as a monorepo containing the following workspaces under the `packages/` directory:
+
+- **[`@mindfiredigital/mdslide-cli` (packages/cli)](/mdslide/packages/cli)**: Command line interface for compiling, watching, linting, and interactive wizard generation.
+- **[`@mindfiredigital/mdslide-core` (packages/core)](/mdslide/packages/core)**: The core compilation engine, slide normalizer, overflow splitted parser, and HTML/PDF/PPTX output renderers.
+- **[`@mindfiredigital/mdslide-parser` (packages/parser)](/mdslide/packages/parser)**: Standalone markdown parser producing MDAST JSON format, exposing programmatic defaults (with position coordinates cleaning option) and a standalone CLI.
+- **[`@mindfiredigital/mdslide-shared` (packages/shared)](/mdslide/packages/shared)**: Shared common utility functions, helpers, and TypeScript types.
+
+---
+
+## 🛠 Getting Started
+
+### Prerequisites
+
+- [Bun](https://bun.sh) (v1.x or higher) installed on your system.
+
+### Installation
+
+fork the repository and install dependencies at the root:
+
+```bash
+bun install
+```
+
+### Local Development Commands
+
+Run the following scripts from the root directory:
+
+- **Build all packages**:
+  ```bash
+  bun run build
+  ```
+- **Start development / watch mode**:
+  ```bash
+  bun run dev
+  ```
+- **Format codebase**:
+  ```bash
+  bun run format
+  ```
+- **Lint codebase**:
+  ```bash
+  bun run lint
+  ```
+- **Run tests**:
+  ```bash
+  bun run test
+  ```
+- **Run test coverage**:
+  ```bash
+  bun run test:coverage
+  ```
+
+---
+
+## 👩‍💻 Developer Guide
+
+We welcome contributions! Please follow this developer guide to ensure smooth collaboration.
+
+### 1. Opening an Issue
+
+Before starting any implementation, please search existing issues or open a new one to discuss:
+
+- **Bug reports**: Include steps to reproduce, expected vs actual behavior, and environment info (OS, Bun version).
+- **Feature requests**: Describe the use-case, proposed API/options, and why it is beneficial.
+
+### 2. Developing Features
+
+- Create a new branch off `dev`:
+  ```bash
+  git checkout -b feature/your-feature-name
+  ```
+- Always add unit tests for your changes. Tests are located in `packages/<package>/tests/`.
+- Ensure tests, formatting, and linting pass locally before proposing changes:
+  ```bash
+  bun run format
+  bun run lint
+  bun run test
+  ```
+
+### 3. Creating a Changeset
+
+We use Changesets to track package version updates and generate changelogs automatically. If your changes affect user-facing code:
+
+- Run the changeset command:
+  ```bash
+  bun changeset
+  ```
+- Select the package(s) that were modified and the bump type (major, minor, or patch).
+- Enter a description of what changed. This will be added to the `.changeset` directory and committed.
+
+### 4. Submitting a Pull Request
+
+- Push your branch to GitHub and open a Pull Request (PR) targeting the `dev` branch.
+- Explain the implementation details, how it was tested, and link the related issue.
+- Ensure all CI workflow tests pass on your PR.
+
+### 5. Versioning & Publishing (Maintainers)
+
+When merging to the default branch:
+
+- Changes merged to `dev` will be staged.
+- Once ready for release, changes are merged into `main`.
+- The Release CI workflow automatically detects changesets, bumps versions, publishes packages to npm, builds compiled binaries for various platforms, and uploads them to a GitHub Release.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,202 @@
+# mdslide
+
+`mdslide` is a modular, high-performance monorepo compiler and presentation tool that converts Markdown documents into gorgeous interactive slide decks in HTML, PDF, or editable/screenshot PPTX formats.
+
+---
+
+## 📦 Project Structure
+
+The project is structured as a monorepo containing the following workspaces under the `packages/` directory:
+
+- **[`@mindfiredigital/mdslide-cli` (packages/cli)](/mdslide/packages/cli)**: Command line interface for compiling, watching, linting, and interactive wizard generation.
+- **[`@mindfiredigital/mdslide-core` (packages/core)](/mdslide/packages/core)**: The core compilation engine, slide normalizer, overflow splitted parser, and HTML/PDF/PPTX output renderers.
+- **[`@mindfiredigital/mdslide-parser` (packages/parser)](/mdslide/packages/parser)**: Standalone markdown parser producing MDAST JSON format, exposing programmatic defaults (with position coordinates cleaning option) and a standalone CLI.
+- **[`@mindfiredigital/mdslide-shared` (packages/shared)](/mdslide/packages/shared)**: Shared common utility functions, helpers, and TypeScript types.
+
+---
+
+## 🛠 Getting Started
+
+### Prerequisites
+
+- [Bun](https://bun.sh) (v1.x or higher) installed on your system.
+
+### Installation
+
+Clone the repository and install dependencies at the root:
+
+```bash
+bun install
+```
+
+### Local Development Commands
+
+Run the following scripts from the root directory:
+
+- **Build all packages**:
+  ```bash
+  bun run build
+  ```
+- **Start development / watch mode**:
+  ```bash
+  bun run dev
+  ```
+- **Format codebase**:
+  ```bash
+  bun run format
+  ```
+- **Lint codebase**:
+  ```bash
+  bun run lint
+  ```
+- **Run tests**:
+  ```bash
+  bun run test
+  ```
+- **Run test coverage**:
+  ```bash
+  bun run test:coverage
+  ```
+
+---
+
+## 🚀 Using the CLI (Quick Start)
+
+To install and use `mdslide` globally:
+
+```bash
+npm install -g @mindfiredigital/mdslide-cli
+# or
+bun add -g @mindfiredigital/mdslide-cli
+```
+
+### Core Commands
+
+- **Interactive Prompt Wizard**: Run a guided walkthrough to choose options.
+  ```bash
+  mdslide slides.md
+  ```
+- **Compile Presentations**: Build standard output formats.
+  ```bash
+  mdslide compile slides.md --theme gradient --open
+  ```
+- **Hot-Reload Live Server**: Start a dev server that refreshes your browser automatically on save.
+  ```bash
+  mdslide watch slides.md --port 3500 --open
+  ```
+- **Initialize Templates**: Scaffold a sample presentation and configuration file in your directory.
+  ```bash
+  mdslide init
+  ```
+- **Validate & Lint Layouts**: Scan your presentation for warnings or slide content overflows.
+  ```bash
+  mdslide validate slides.md
+  ```
+
+---
+
+## ✍️ Presentation Syntax & Authoring Guide
+
+`mdslide` compiles standard Markdown files. You control structure using YAML frontmatter, slide dividers (`---`), and layout comment annotations.
+
+### 1. Global Document Configurations (YAML Frontmatter)
+
+Declare document metadata at the very top of your file between `---` bounds:
+
+```yaml
+---
+title: My Executive Presentation
+theme: gradient # light | dark | notion | terminal | gradient | corporate | solarized
+titleAlign: center # Default title alignment across all slides: left | center | right
+titlePosition: top # Default title vertical position: top | center | bottom
+---
+```
+
+### 2. Slide Separation
+
+- Slides are separated by thematic breaks (`---`) on empty lines.
+- Alternatively, if no `---` breaks are present, the compiler automatically splits slides at each Level-2 Heading (`##`).
+
+### 3. Slide-Level Customizations & Comments
+
+You can override layouts, alignments, backgrounds, and notes on a per-slide basis using annotations:
+
+#### **Layout Overrides**
+
+Force layout styling for a specific slide:
+
+- `<!-- layout: title -->` — Main presentation cover layout.
+- `<!-- layout: bullets -->` — Enhances text lists and bumps font sizing.
+- `<!-- layout: code -->` — Optimizes rendering for full-screen code blocks.
+- `<!-- layout: visual -->` — Fits images prominently within slide boundaries.
+- `<!-- layout: quote -->` — Places quotes inside a styled highlighted card box.
+- `<!-- layout: table -->` — Centers comparison grids.
+- `<!-- layout: statement -->` — Displays single main highlights in a massive font.
+- `<!-- layout: split -->` — Standardizes two-column content layouts.
+
+#### **Slide Title Positioning & Alignment**
+
+- `<!-- titleAlign: center -->` — Align title text for this slide (`left`, `center`, or `right`).
+- `<!-- titlePosition: bottom -->` — Vertically position this slide's title (`top`, `center`, or `bottom`).
+
+#### **Background Images**
+
+Set a slide background image using:
+
+```markdown
+<!-- backgroundImage: url('https://example.com/slide-bg.jpg') -->
+```
+
+- **Luminance Detection**: `mdslide` automatically analyzes the background image on load. If the image is dark, it inverts slide text to white; if light, it uses dark text with drop-shadows.
+- **Manual Override**: Append `dark` or `light` to the URL inside the comment to force text theme:
+  ```markdown
+  <!-- backgroundImage: url('bg.jpg') dark -->
+  ```
+
+#### **Presenter Speaker Notes**
+
+Add speaker notes that sync automatically to the Presenter View pop-up window:
+
+```markdown
+<!-- notes -->
+
+This text will be hidden on the presentation view but visible to the speaker.
+
+<!-- /notes -->
+```
+
+### 4. Two-Column Layouts (`::split::`)
+
+You can split any slide into two columns (text on left, content on right) manually by using the `::split::` separator:
+
+```markdown
+# Product Features Comparison
+
+Left Column Header
+
+- High scalability
+- Easy installation
+- Modular design
+
+::split::
+
+Right Column Header
+
+- 24/7 technical support
+- Extended warranty options
+- Comprehensive API docs
+```
+
+- **Auto-Split**: If a slide contains exactly one image alongside text, `mdslide` automatically converts the layout into a split view, placing text on the left and the image on the right.
+
+---
+
+## Contributing
+
+We welcome contributions from the community. Please follow our [Contributing Guidelines](CONTRIBUTING.md).
+
+## License
+
+Copyright (c) Mindfire Digital LLP. All rights reserved.
+
+Licensed under the MIT license.

--- a/bun.lock
+++ b/bun.lock
@@ -49,9 +49,11 @@
         "@mindfiredigital/mdslide-parser": "workspace:*",
         "@mindfiredigital/mdslide-shared": "workspace:*",
         "gray-matter": "^4.0.3",
+        "katex": "^0.16.9",
         "mdast-util-to-string": "^4.0.0",
       },
       "devDependencies": {
+        "@types/katex": "^0.16.7",
         "@types/mdast": "^4.0.4",
         "@types/node": "^25.6.0",
         "tsup": "^8.0.0",
@@ -65,6 +67,7 @@
       },
       "dependencies": {
         "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0",
         "remark-parse": "^11.0.0",
         "unified": "^11.0.5",
       },
@@ -410,7 +413,11 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/katex": ["@types/katex@0.16.8", "", {}, "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
@@ -898,6 +905,8 @@
 
     "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
 
+    "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
@@ -982,6 +991,8 @@
 
     "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
 
+    "mdast-util-math": ["mdast-util-math@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "longest-streak": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.1.0", "unist-util-remove-position": "^5.0.0" } }, "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w=="],
+
     "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
 
     "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
@@ -1011,6 +1022,8 @@
     "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
 
     "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-extension-math": ["micromark-extension-math@3.1.0", "", { "dependencies": { "@types/katex": "^0.16.0", "devlop": "^1.0.0", "katex": "^0.16.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg=="],
 
     "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
 
@@ -1174,6 +1187,8 @@
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
+    "remark-math": ["remark-math@6.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-math": "^3.0.0", "micromark-extension-math": "^3.0.0", "unified": "^11.0.0" } }, "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA=="],
+
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
@@ -1328,6 +1343,8 @@
 
     "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 
+    "unist-util-remove-position": ["unist-util-remove-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q=="],
+
     "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
 
     "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
@@ -1447,6 +1464,8 @@
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "lint-staged/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "prettier": "^3.8.1",
         "start-server-and-test": "^3.0.11",
         "tsup": "^8.5.1",
+        "turbo": "^2.9.18",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.57.1",
         "vitest": "^4.1.0",
@@ -384,6 +385,18 @@
     "@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.2.0", "", {}, "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.18", "", { "os": "darwin", "cpu": "x64" }, "sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw=="],
+
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.18", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ=="],
+
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.18", "", { "os": "linux", "cpu": "x64" }, "sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw=="],
+
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg=="],
+
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.18", "", { "os": "win32", "cpu": "x64" }, "sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw=="],
+
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.18", "", { "os": "win32", "cpu": "arm64" }, "sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
@@ -1294,6 +1307,8 @@
     "tsup": ["tsup@8.5.1", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.27.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "^0.7.6", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
+
+    "turbo": ["turbo@2.9.18", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.18", "@turbo/darwin-arm64": "2.9.18", "@turbo/linux-64": "2.9.18", "@turbo/linux-arm64": "2.9.18", "@turbo/windows-64": "2.9.18", "@turbo/windows-arm64": "2.9.18" }, "bin": { "turbo": "bin/turbo" } }, "sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg=="],
 
     "tweetnacl": ["tweetnacl@0.14.5", "", {}, "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="],
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "bun@1.2.23",
   "scripts": {
-    "build": "bun run --filter ./packages/shared build && bun run --filter ./packages/parser build && bun run --filter ./packages/core build &&bun run --filter ./packages/cli build",
+    "build": "turbo run build",
     "dev": "bun run --filter \"*\" dev",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -17,7 +17,8 @@
     "e2e:run": "start-server-and-test 'bun packages/cli/dist/cli.js watch presentation-e2e.md --port 3030' http://localhost:3030 'cypress run'",
     "e2e:open": "start-server-and-test 'bun packages/cli/dist/cli.js watch presentation-e2e.md --port 3030' http://localhost:3030 'cypress open'",
     "version": "changeset version",
-    "release": "changeset publish"
+    "release": "bun run build && changeset publish",
+    "changeset": "changeset"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
@@ -33,6 +34,7 @@
     "prettier": "^3.8.1",
     "start-server-and-test": "^3.0.11",
     "tsup": "^8.5.1",
+    "turbo": "^2.9.18",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.1",
     "vitest": "^4.1.0"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,331 @@
+# @mindfiredigital/mdslide-cli
+
+> **mdslide** is a modern, modular, high-performance compiler and presentation tool that converts Markdown documents into gorgeous interactive slide decks in HTML, PDF, or PowerPoint (PPTX) formats.
+
+---
+
+## 🚀 Key Features
+
+- ⚡ **Auto-live preview / hot-reload server**: Automatically compiles and updates your browser presentation as you edit your markdown.
+- 🎨 **Gorgeous Built-in Themes**: Clean, modern aesthetics out-of-the-box (`light`, `dark`, `notion`, `terminal`, `gradient`, `corporate`, `solarized`).
+- 📦 **Multi-format Exports**: Generate presentation-ready standalone HTML, printable PDF, or PowerPoint (PPTX) files (supports both screenshot and editable text layouts).
+- 📏 **Smart Layout Engine**: Detects your content structure to apply the best matching layout (e.g. `bullets`, `code`, `visual`, `table`, `quote`, `statement`).
+- 🧩 **List & Code Overflow Splitting**: Automatically flows long code blocks and lists across multiple slides to prevent layout overflow.
+- 💬 **Speaker Notes Panel**: Native presenter view support for your presentation delivery.
+
+---
+
+## 📦 Installation
+
+Install the CLI globally using your preferred package manager:
+
+```bash
+npm install -g @mindfiredigital/mdslide-cli
+# or
+bun add -g @mindfiredigital/mdslide-cli
+```
+
+---
+
+## 📖 Writing Your Presentation
+
+Creating slides in `mdslide` is simple. Slides are separated by thematic breaks (`---`), and your slide settings are configured at the top using frontmatter.
+
+### Sample Slide Deck (`slides.md`)
+
+````markdown
+---
+title: Building with mdslide
+theme: gradient
+---
+
+# Introduction to mdslide
+
+### High-Performance Markdown Presentations
+
+<!-- notes -->
+
+Welcome everyone! Introduce myself and set the stage for how mdslide simplifies presentation authoring.
+
+<!-- /notes -->
+
+---
+
+<!-- layout: bullets -->
+
+## Core Advantages
+
+- **Write in Markdown**: Focus entirely on your content.
+- **Smart Formatting**: Zero manual alignments or coordinate styling.
+- **Presenter Mode**: Built-in dual-screen window speaker notes.
+
+---
+
+<!-- layout: code -->
+
+## Zero Configuration Code Slides
+
+```typescript
+import { defineConfig } from '@mindfiredigital/mdslide-cli';
+
+export default defineConfig({
+  theme: 'dark',
+  watch: { open: true },
+});
+```
+````
+
+---
+
+<!-- layout: quote -->
+
+> "Simplicity is the ultimate sophistication."
+> — Leonardo da Vinci
+
+---
+
+<!-- layout: table -->
+
+## Formats Comparison
+
+| Feature                 |  HTML  |  PDF   |    PPTX    |
+| :---------------------- | :----: | :----: | :--------: |
+| Interactive Transitions | ✅ Yes | ❌ No  |   ✅ Yes   |
+| Standalone File         | ✅ Yes | ✅ Yes |   ✅ Yes   |
+| Vector Graphics         | ✅ Yes | ✅ Yes | ⚠️ Partial |
+
+---
+
+<!-- layout: statement -->
+
+# Thank You!
+
+### Let's start compiling.
+
+````
+
+---
+
+## 🛠 Slide Controls & Layout Comments
+
+### 1. Slide Separation
+* **Manual Separation**: Use `---` on a blank line.
+* **Auto-Separation**: Level-2 headings (`##`) automatically start a new slide (unless overridden).
+
+### 2. Layout Overrides
+You can manually force a layout on any slide using an HTML comment:
+* `<!-- layout: title -->` (Main title layout)
+* `<!-- layout: bullets -->` (Bumps font size and styles lists nicely)
+* `<!-- layout: code -->` (Full-width preformatted syntax highlighted code block)
+* `<!-- layout: visual -->` (Displays images prominently)
+* `<!-- layout: quote -->` (Stylized blockquote focus)
+* `<!-- layout: table -->` (Formats tables centrally)
+* `<!-- layout: statement -->` (Giant centered message layout)
+* `<!-- layout: split -->` (Multi-column content structure layout)
+
+### 3. Multi-Column Split (`::split::`)
+To split content on a slide into two equal side-by-side columns:
+```markdown
+# Columns Layout
+
+Left Column contents.
+- Item A
+- Item B
+
+::split::
+
+Right Column contents.
+- Item C
+- Item D
+````
+
+### 4. Slide Title Alignments & Positions
+
+Override defaults for a slide's title block:
+
+- `<!-- titleAlign: center -->` — Horizontal alignment: `left` | `center` | `right`
+- `<!-- titlePosition: bottom -->` — Vertical position: `top` | `center` | `bottom`
+
+### 5. Slide Background Images
+
+Set a background image using:
+
+```markdown
+<!-- backgroundImage: url('https://example.com/image.jpg') -->
+```
+
+- **Smart Contrast**: `mdslide` automatically reads the image on load. If it's a dark background image, slide text automatically flips to white; if it's light, text shifts to dark gray with subtle shadows.
+- **Manual Style Override**: Force contrast themes by appending `dark` or `light` inside the comment:
+  ```markdown
+  <!-- backgroundImage: url('image.jpg') dark -->
+  ```
+
+### 6. Speaker Notes
+
+Wrap notes inside comment blocks anywhere on a slide. These will be visible in the presenter console window during presentation:
+
+```markdown
+<!-- notes -->
+
+Your presenter notes go here.
+
+<!-- /notes -->
+```
+
+---
+
+## 💻 CLI Commands & Usage
+
+`mdslide` offers several commands to manage, compile, preview, and validate your markdown slides.
+
+```bash
+mdslide <command> [input] [options]
+```
+
+### 1. Interactive Mode (Default)
+
+Running the binary with just your input markdown file (without specifying a subcommand) launches an interactive CLI wizard.
+
+```bash
+mdslide slides.md
+```
+
+- **What it does**: Starts an interactive prompt wizard that guides you to choose your theme, output format, destination file path, and whether to launch the live preview server or run a single compilation.
+- **Input**: A path to your markdown file.
+- **Output**: Prompts terminal questions and then compiled output files or triggers a watch server.
+
+---
+
+### 2. Compile Slides (`mdslide compile`)
+
+Compiles a Markdown presentation into a single target file.
+
+```bash
+mdslide compile <input> [options]
+```
+
+- **What it does**: Performs a one-time build parsing your markdown, styling it using the specified theme, resolving layout elements, and rendering the selected presentation output format.
+- **Input**: Path to your markdown file (`<input>`).
+- **Options**:
+  - `-t, --theme <theme>`: Theme choice (`light`, `dark`, `notion`, `terminal`, `gradient`, `corporate`, `solarized`).
+  - `-o, --output <file>`: Output file path. Defaults to `output.<format>` (e.g. `output.html`).
+  - `-f, --format <format>`: Format type (`html` | `pdf` | `pptx`). Auto-detected from your `-o` file extension if omitted.
+  - `--pptx-mode <mode>`: PPTX layout generation mode. `screenshot` compiles slides exactly as they appear in browser view; `editable` translates lists/text elements into editable PPTX shapes. Default: `screenshot`.
+  - `-i, --interactive`: Explicitly forces compilation via the interactive wizard.
+  - `--open`: Opens the compiled presentation immediately in your browser or default system application.
+  - `--strict`: Exits compilation with an error code if any parser warnings are raised.
+  - `--verbose`: Logs detailed compilation and layout diagnostic reports.
+  - `--silent`: Suppresses all console output.
+- **Output**: A generated file (e.g., `output.html`, `output.pdf`, `output.pptx`) containing your structured presentation slides.
+
+**Examples:**
+
+```bash
+mdslide compile slides.md --theme dark --open
+mdslide compile slides.md -o quarterly-report.pdf
+mdslide compile slides.md -f pptx --pptx-mode editable
+```
+
+---
+
+### 3. Hot-Reload Dev Server (`mdslide watch`)
+
+Starts a local development server with live-reloading.
+
+```bash
+mdslide watch <input> [options]
+```
+
+- **What it does**: Watches your input markdown file for changes. Whenever you edit and save your file, the CLI automatically compiles it behind the scenes and pushes updates to your browser instantly without manual page refreshes.
+- **Input**: Path to your markdown file (`<input>`).
+- **Options**:
+  - `-t, --theme <theme>`: Theme override choice.
+  - `-p, --port <port>`: Port to bind the dev server. Default: `3500`.
+  - `--open`: Automatically opens your presentation in your default web browser on launch.
+  - `--verbose`: Logs detailed file changes and reload events.
+  - `--silent`: Suppresses all terminal logging.
+- **Output**: A running local server at `http://localhost:<port>` presenting your interactive slide deck, reflecting modifications in real-time.
+
+**Examples:**
+
+```bash
+mdslide watch slides.md --port 4000 --open
+```
+
+---
+
+### 4. Create Template Config (`mdslide init`)
+
+Scaffolds a new configuration template and sample presentation in your current directory.
+
+```bash
+mdslide init [options]
+```
+
+- **What it does**: Generates a default `mdslide.config.ts` configuration file and a sample `slides.md` deck to help you start presenting quickly. If a `package.json` file is present in your current working directory, it will automatically append `"dev"` and `"build"` scripts.
+- **Input**: None.
+- **Options**:
+  - `--force`: Overwrites existing `slides.md` or `mdslide.config.ts` files if they exist.
+  - `--silent`: Suppresses all console logs.
+- **Output**:
+  - A `slides.md` file pre-filled with demo slides.
+  - A `mdslide.config.ts` file pre-populated with structure settings.
+  - Modified `package.json` (if present) containing helper script shortcuts.
+
+---
+
+### 5. Check Layout & Lint Issues (`mdslide validate`)
+
+Sanity checks your slide deck for formatting and budget issues.
+
+```bash
+mdslide validate <input> [options]
+```
+
+- **What it does**: Scans your markdown presentation for syntax anomalies, invalid layout overrides, broken local image assets, and checks if slide contents exceed heights/vertical budget constraints (which could cause slide overflow).
+- **Input**: Path to your markdown file (`<input>`).
+- **Options**:
+  - `--strict`: Exits with status code `1` if any warning level messages are found.
+  - `--verbose`: Outputs verbose warnings and checks.
+  - `--silent`: Suppresses all output.
+- **Output**: A structured terminal diagnostic report containing `Errors` (must-fix) and `Warnings` (recommendations).
+
+---
+
+### 6. Interactive Command (`mdslide interactive`)
+
+Explicitly runs the interactive wizard.
+
+```bash
+mdslide interactive <input> [options]
+```
+
+- **What it does**: Acts as a shortcut to trigger the interactive walkthrough wizard for compiling or watching.
+- **Input**: Path to your markdown file (`<input>`).
+- **Options**:
+  - `--verbose`/`--silent`: Logging level modifiers.
+- **Output**: Interactive questions followed by compile or preview server launches.
+
+---
+
+## ⚙️ Configuration File (`mdslide.config.ts`)
+
+You can customize compilation defaults using a configuration file in your root folder.
+
+Create a `mdslide.config.ts` file:
+
+```typescript
+import { defineConfig } from '@mindfiredigital/mdslide-cli';
+
+export default defineConfig({
+  theme: 'gradient',
+  output: 'dist/presentation.html',
+  watch: {
+    port: 4200,
+    open: true,
+  },
+  pdf: {
+    printBackground: true,
+  },
+});
+```

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -105,6 +105,7 @@ export async function compileCommand(inputFile: string, opts: CompileOptions): P
       await compileToPdf(html, absOutput, {
         chromePath: process.env['CHROME_PATH'],
         timeoutMs: opts.pdfTimeoutMs ?? 30_000,
+        baseDir: path.dirname(path.resolve(inputFile)),
       });
     } else if (format === 'pptx') {
       const pptxMode = opts.pptxMode ?? 'screenshot';

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -21,9 +21,13 @@ function validateSlides(markdown: string, filePath?: string): ValidationIssue[] 
 
   // 1. Parse Frontmatter
   let frontmatterContent = markdown;
+  let defaultOverflow: string | undefined;
   try {
     const { meta, content } = parseFrontmatter(markdown);
     frontmatterContent = content;
+    if (meta.overflow && typeof meta.overflow === 'string') {
+      defaultOverflow = meta.overflow.toLowerCase();
+    }
 
     // Validate Frontmatter keys
     if (meta.theme !== undefined) {
@@ -86,7 +90,11 @@ function validateSlides(markdown: string, filePath?: string): ValidationIssue[] 
     }
 
     // Used rule limit constant here
-    if (lines.length > VALIDATION_RULES.MAX_LINES_PER_SLIDE) {
+    const hasOverflowSplit =
+      defaultOverflow === 'split' ||
+      lines.some((l) => /^<!--\s*overflow:\s*split\s*-->$/i.test(l.trim()));
+
+    if (!hasOverflowSplit && lines.length > VALIDATION_RULES.MAX_LINES_PER_SLIDE) {
       issues.push({
         type: 'warning',
         slide: slideNo,

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -9,7 +9,7 @@ import { onShutdown } from '../middleware/signals.js';
 import { InputNotFoundError, PortInUseError } from '../middleware/errors.js';
 import { runCompile } from './compile.js';
 import type { WatchOptions } from '../types/index.js';
-import { link } from '../utils/index.js';
+import { link, createStaticServer } from '../utils/index.js';
 import { WATCH_CONFIG, WATCH_MESSAGES, ERROR_OVERLAY_TEMPLATE } from '../constants/index.js';
 
 function buildErrorHtml(err: unknown): string {
@@ -66,36 +66,34 @@ export async function watchCommand(inputFile: string, opts: WatchOptions): Promi
     process.exit(1);
   }
 
-  const server = http.createServer((req, res) => {
-    const url = req.url ?? '/';
+  const liveReloadHandler = (req: http.IncomingMessage, res: http.ServerResponse) => {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    });
+    res.write(': connected\n\n');
+    clients.push(res);
 
-    // Used route config constant here
-    if (url === WATCH_CONFIG.LIVE_RELOAD_PATH) {
-      res.writeHead(200, {
-        'Content-Type': 'text/event-stream',
-        'Cache-Control': 'no-cache',
-        Connection: 'keep-alive',
-        'X-Accel-Buffering': 'no',
-      });
-      res.write(': connected\n\n');
-      clients.push(res);
+    const heartbeat = setInterval(
+      () => res.write(': ping\n\n'),
+      WATCH_CONFIG.SSE_HEARTBEAT_INTERVAL_MS
+    );
+    req.on('close', () => {
+      clearInterval(heartbeat);
+      const i = clients.indexOf(res);
+      if (i !== -1) clients.splice(i, 1);
+    });
+  };
 
-      // Used SSE timing variable here
-      const heartbeat = setInterval(
-        () => res.write(': ping\n\n'),
-        WATCH_CONFIG.SSE_HEARTBEAT_INTERVAL_MS
-      );
-      req.on('close', () => {
-        clearInterval(heartbeat);
-        const i = clients.indexOf(res);
-        if (i !== -1) clients.splice(i, 1);
-      });
-      return;
-    }
-
-    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-    res.end(cachedHtml);
-  });
+  const baseDir = path.dirname(absInput);
+  const server = createStaticServer(
+    () => cachedHtml,
+    baseDir,
+    WATCH_CONFIG.LIVE_RELOAD_PATH,
+    liveReloadHandler
+  );
 
   server.listen(port, () => {
     const url = `http://localhost:${port}`;

--- a/packages/cli/src/constants/exports/pdfConstants.ts
+++ b/packages/cli/src/constants/exports/pdfConstants.ts
@@ -7,20 +7,66 @@ export const PDF_CONFIG = {
     process.env['CHROMIUM_PATH'],
     '/usr/bin/google-chrome',
     '/usr/bin/google-chrome-stable',
-    '/usr/bin/chromium-browser',
-    '/usr/bin/chromium',
+    '/usr/bin/google-chrome-beta',
+    '/usr/bin/google-chrome-unstable',
+    '/opt/google/chrome/google-chrome',
+
     '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '~/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+
+    'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+    'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+    'C:\\Users\\<User>\\AppData\\Local\\Google\\Chrome\\Application\\chrome.exe',
+
+    // Chromium
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+    '/snap/bin/chromium',
+    '/opt/chromium/chromium',
+
     '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    '~/Applications/Chromium.app/Contents/MacOS/Chromium',
+
+    'C:\\Program Files\\Chromium\\Application\\chrome.exe',
+    'C:\\Program Files (x86)\\Chromium\\Application\\chrome.exe',
+    'C:\\Users\\<User>\\AppData\\Local\\Chromium\\Application\\chrome.exe',
+
+    // Microsoft Edge
+    '/usr/bin/microsoft-edge',
+    '/usr/bin/microsoft-edge-stable',
+    '/opt/microsoft/msedge/msedge',
+
+    '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+    '~/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+
+    'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
+    'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
+    'C:\\Users\\<User>\\AppData\\Local\\Microsoft\\Edge\\Application\\msedge.exe',
+
+    // Brave Browser
+    '/usr/bin/brave-browser',
+    '/usr/bin/brave-browser-stable',
+    '/usr/bin/brave-browser-beta',
+    '/opt/brave.com/brave/brave-browser',
+
+    '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+    '~/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+
+    'C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe',
+    'C:\\Program Files (x86)\\BraveSoftware\\Brave-Browser\\Application\\brave.exe',
+    'C:\\Users\\<User>\\AppData\\Local\\BraveSoftware\\Brave-Browser\\Application\\brave.exe',
   ].filter(Boolean) as string[],
-  CHROME_ARGS: (outputPath: string, htmlPath: string) => [
+  CHROME_ARGS: (outputPath: string, url: string) => [
     '--headless',
     '--disable-gpu',
     '--no-sandbox',
     '--disable-setuid-sandbox',
     '--disable-dev-shm-usage',
+    '--run-all-compositor-stages-before-draw',
+    '--virtual-time-budget=10000',
     `--print-to-pdf=${outputPath}`,
     '--print-to-pdf-no-header',
-    htmlPath,
+    url,
   ],
 } as const;
 

--- a/packages/cli/src/constants/logs/validationCommandLogs.ts
+++ b/packages/cli/src/constants/logs/validationCommandLogs.ts
@@ -44,6 +44,7 @@ export const SUPPORTED_LANGS = [
   'sql',
   'yaml',
   'yml',
+  'mermaid',
 ] as const;
 
 export const VALIDATION_MESSAGES = {

--- a/packages/cli/src/exports/pdfExports.ts
+++ b/packages/cli/src/exports/pdfExports.ts
@@ -4,6 +4,7 @@ import { spawn } from 'child_process';
 import { execFileSync } from 'child_process';
 import { PdfExportOptions } from '../types/index.js';
 import { PDF_CONFIG, PDF_MESSAGES } from '../constants/index.js';
+import { createStaticServer, getFreePort } from '../utils/index.js';
 
 export function findChromeBinary(): string | null {
   for (const bin of PDF_CONFIG.CHROME_CANDIDATES) {
@@ -16,7 +17,7 @@ export function findChromeBinary(): string | null {
 }
 
 export function exportToPdf(
-  htmlPath: string,
+  url: string,
   outputPath: string,
   opts: PdfExportOptions = {}
 ): Promise<void> {
@@ -27,7 +28,7 @@ export function exportToPdf(
     return Promise.reject(new Error(PDF_MESSAGES.CHROME_NOT_FOUND));
   }
 
-  const args = PDF_CONFIG.CHROME_ARGS(outputPath, htmlPath);
+  const args = PDF_CONFIG.CHROME_ARGS(outputPath, url);
 
   return new Promise((resolve, reject) => {
     const child = spawn(chromeBin, args, { stdio: ['ignore', 'ignore', 'pipe'] });
@@ -68,17 +69,23 @@ export async function compileToPdf(
   outputPath: string,
   opts: PdfExportOptions = {}
 ): Promise<void> {
-  const dir = path.dirname(path.resolve(outputPath));
-  const tempPath = path.join(dir, `.mdslide-tmp-${Date.now()}.html`);
+  const baseDir = opts.baseDir ?? path.dirname(path.resolve(outputPath));
+  const port = await getFreePort();
 
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(tempPath, html, 'utf8');
+  const server = createStaticServer(() => html, baseDir);
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(port, '127.0.0.1', () => resolve());
+    server.once('error', reject);
+  });
+
+  const url = `http://127.0.0.1:${port}/`;
 
   try {
-    await exportToPdf(tempPath, path.resolve(outputPath), opts);
+    await exportToPdf(url, path.resolve(outputPath), opts);
   } finally {
-    try {
-      fs.unlinkSync(tempPath);
-    } catch {}
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
   }
 }

--- a/packages/cli/src/exports/pptxScreenshotExporter.ts
+++ b/packages/cli/src/exports/pptxScreenshotExporter.ts
@@ -1,69 +1,11 @@
 import fs from 'fs';
 import path from 'path';
-import http from 'http';
-import net from 'net';
 import os from 'os';
 import { spawn } from 'child_process';
 import pptxgen from 'pptxgenjs';
 import { findChromeBinary } from './pdfExports.js';
 import { ScreenshotPptxOptions } from '../types/index.js';
-
-function getFreePort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const s = net.createServer();
-    s.listen(0, () => {
-      const addr = s.address() as net.AddressInfo;
-      s.close(() => resolve(addr.port));
-    });
-    s.on('error', reject);
-  });
-}
-
-// Local HTTP server for serving slide HTML and its static assets
-function serveHtml(html: string, port: number, baseDir: string): Promise<() => void> {
-  return new Promise((resolve, reject) => {
-    const server = http.createServer((req, res) => {
-      const urlPath = req.url ? req.url.split('?')[0] : '/';
-
-      if (urlPath === '/' || urlPath === '/index.html') {
-        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-        res.end(html);
-        return;
-      }
-
-      // Try serving static files relative to baseDir
-      const filePath = path.join(baseDir, decodeURIComponent(urlPath));
-      fs.stat(filePath, (err, stats) => {
-        if (err || !stats.isFile()) {
-          res.writeHead(404, { 'Content-Type': 'text/plain' });
-          res.end('Not Found');
-          return;
-        }
-
-        let contentType = 'application/octet-stream';
-        const ext = path.extname(filePath).toLowerCase();
-        if (ext === '.css') contentType = 'text/css';
-        else if (ext === '.js') contentType = 'application/javascript';
-        else if (ext === '.json') contentType = 'application/json';
-        else if (ext === '.png') contentType = 'image/png';
-        else if (ext === '.jpg' || ext === '.jpeg') contentType = 'image/jpeg';
-        else if (ext === '.gif') contentType = 'image/gif';
-        else if (ext === '.svg') contentType = 'image/svg+xml';
-        else if (ext === '.woff') contentType = 'font/woff';
-        else if (ext === '.woff2') contentType = 'font/woff2';
-        else if (ext === '.ttf') contentType = 'font/ttf';
-
-        res.writeHead(200, { 'Content-Type': contentType });
-        fs.createReadStream(filePath).pipe(res);
-      });
-    });
-
-    server.listen(port, '127.0.0.1', () => {
-      resolve(() => server.close());
-    });
-    server.once('error', reject);
-  });
-}
+import { createStaticServer, getFreePort } from '../utils/index.js';
 
 function screenshotSlide(
   chromeBin: string,
@@ -82,7 +24,7 @@ function screenshotSlide(
       '--disable-dev-shm-usage',
       '--hide-scrollbars',
       '--run-all-compositor-stages-before-draw',
-      '--virtual-time-budget=5000',
+      '--virtual-time-budget=10000',
       `--window-size=${width},${height}`,
       `--screenshot=${outputPng}`,
       url,
@@ -143,6 +85,10 @@ function injectSlideSelector(html: string): string {
     opacity: 0 !important;
     display: none !important;
   }
+  /* Enforce fragment visibility in screenshots */
+  .fragment {
+    opacity: 1 !important;
+  }
 </style>
 `;
 
@@ -202,16 +148,21 @@ export async function compileToScreenshotPptx(
     } catch {}
   };
 
+  const modifiedHtml = injectSlideSelector(html);
+
+  // Start local HTTP server directly out of system RAM memory
+  const serverPort = await getFreePort();
+  const server = createStaticServer(() => modifiedHtml, opts.baseDir ?? process.cwd());
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(serverPort, '127.0.0.1', () => resolve());
+    server.once('error', reject);
+  });
+
+  const baseUrl = `http://127.0.0.1:${serverPort}`;
+  const pngPaths: string[] = [];
+
   try {
-    const modifiedHtml = injectSlideSelector(html);
-
-    // Start local HTTP server directly out of system RAM memory
-    const serverPort = await getFreePort();
-    const stopServer = await serveHtml(modifiedHtml, serverPort, opts.baseDir ?? process.cwd());
-    const baseUrl = `http://127.0.0.1:${serverPort}`;
-
-    const pngPaths: string[] = [];
-
     // Screenshot each slide sequentially to avoid CPU/resource overload
     for (let i = 0; i < slideCount; i++) {
       const pngPath = path.join(tmpDir, `slide-${i}.png`);
@@ -220,9 +171,11 @@ export async function compileToScreenshotPptx(
 
       await screenshotSlide(chromeBin, url, pngPath, width, height, timeoutMs);
     }
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
 
-    stopServer();
-
+  try {
     // Build PPTX with screenshots as full-bleed images
     const pptx = new (pptxgen as any)();
     pptx.layout = 'LAYOUT_WIDE';

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -84,6 +84,7 @@ export interface PdfExportOptions {
   chromePath?: string;
   timeoutMs?: number;
   printBackground?: boolean;
+  baseDir?: string;
 }
 
 export interface ScreenshotPptxOptions {

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -1,6 +1,8 @@
 import { icons } from '../assets/index.js';
 import { STYLES, COLORS } from '../constants/index.js';
 
+export * from './server.js';
+
 export function c(color: string, text: string): string {
   if (!process.stdout.isTTY) return text;
   return `${color}${text}${STYLES.reset}`;

--- a/packages/cli/src/utils/server.ts
+++ b/packages/cli/src/utils/server.ts
@@ -1,0 +1,92 @@
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import net from 'net';
+
+export function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const s = net.createServer();
+    s.listen(0, () => {
+      const addr = s.address() as net.AddressInfo;
+      s.close(() => resolve(addr.port));
+    });
+    s.on('error', reject);
+  });
+}
+
+export function createStaticServer(
+  getHtml: () => string,
+  baseDir: string,
+  liveReloadPath?: string,
+  liveReloadHandler?: (req: http.IncomingMessage, res: http.ServerResponse) => void
+): http.Server {
+  return http.createServer((req, res) => {
+    const urlPath = req.url ? req.url.split('?')[0] : '/';
+
+    // Handshake for live reload SSE
+    if (liveReloadPath && urlPath === liveReloadPath && liveReloadHandler) {
+      liveReloadHandler(req, res);
+      return;
+    }
+
+    // Default route
+    if (urlPath === '/' || urlPath === '/index.html') {
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(getHtml());
+      return;
+    }
+
+    // Delay route to hold back Chrome's load event for PDF/PPTX capture of async components
+    if (urlPath === '/delay-load-event.png') {
+      setTimeout(() => {
+        const buf = Buffer.from(
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+          'base64'
+        );
+        res.writeHead(200, {
+          'Content-Type': 'image/png',
+          'Content-Length': buf.length.toString(),
+          'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
+        });
+        res.end(buf);
+      }, 3000); // 3 seconds delay
+      return;
+    }
+
+    // Resolve static files safely to prevent path traversal
+    const safeBaseDir = path.resolve(baseDir);
+    const decodedUrl = decodeURIComponent(urlPath);
+    const filePath = path.join(safeBaseDir, decodedUrl);
+
+    // Strict path boundary validation to block traversal (e.g. ../../etc/passwd)
+    if (!filePath.startsWith(safeBaseDir)) {
+      res.writeHead(403, { 'Content-Type': 'text/plain' });
+      res.end('Forbidden');
+      return;
+    }
+
+    fs.stat(filePath, (err, stats) => {
+      if (err || !stats.isFile()) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not Found');
+        return;
+      }
+
+      let contentType = 'application/octet-stream';
+      const ext = path.extname(filePath).toLowerCase();
+      if (ext === '.css') contentType = 'text/css';
+      else if (ext === '.js') contentType = 'application/javascript';
+      else if (ext === '.json') contentType = 'application/json';
+      else if (ext === '.png') contentType = 'image/png';
+      else if (ext === '.jpg' || ext === '.jpeg') contentType = 'image/jpeg';
+      else if (ext === '.gif') contentType = 'image/gif';
+      else if (ext === '.svg') contentType = 'image/svg+xml';
+      else if (ext === '.woff') contentType = 'font/woff';
+      else if (ext === '.woff2') contentType = 'font/woff2';
+      else if (ext === '.ttf') contentType = 'font/ttf';
+
+      res.writeHead(200, { 'Content-Type': contentType });
+      fs.createReadStream(filePath).pipe(res);
+    });
+  });
+}

--- a/packages/cli/tests/validate.test.ts
+++ b/packages/cli/tests/validate.test.ts
@@ -16,6 +16,8 @@ describe('CLI Validate Command', () => {
   const frontmatterNonStringThemeMd = path.join(tmpDir, 'frontmatter-non-string-theme.md');
   const emptySlideMd = path.join(tmpDir, 'empty-slide.md');
   const overflowSlideMd = path.join(tmpDir, 'overflow-slide.md');
+  const overflowSplitCommentMd = path.join(tmpDir, 'overflow-split-comment.md');
+  const overflowSplitMetaMd = path.join(tmpDir, 'overflow-split-meta.md');
   const layoutWarningMd = path.join(tmpDir, 'layout-warning.md');
   const multipleLayoutsWarningMd = path.join(tmpDir, 'multiple-layouts.md');
   const unclosedNotesWarningMd = path.join(tmpDir, 'unclosed-notes.md');
@@ -45,6 +47,14 @@ describe('CLI Validate Command', () => {
     fs.writeFileSync(frontmatterNonStringThemeMd, '---\ntheme: 123\n---\n# Page One\n');
     fs.writeFileSync(emptySlideMd, '# Page One\n---\n\n---\n# Page Three\n');
     fs.writeFileSync(overflowSlideMd, '# Page One\n' + Array(35).fill('line').join('\n'));
+    fs.writeFileSync(
+      overflowSplitCommentMd,
+      '# Page One\n<!-- overflow: split -->\n' + Array(35).fill('line').join('\n')
+    );
+    fs.writeFileSync(
+      overflowSplitMetaMd,
+      '---\noverflow: split\n---\n# Page One\n' + Array(35).fill('line').join('\n')
+    );
     fs.writeFileSync(layoutWarningMd, '# Page One\n<!-- layout: nonexistent-layout -->\n');
     fs.writeFileSync(
       multipleLayoutsWarningMd,
@@ -209,5 +219,17 @@ describe('CLI Validate Command', () => {
     await validateCommand(overflowSlideMd, { logLevel: 'info' });
     const output = logSpy.mock.calls.map((c: any) => c[0]).join('\n');
     expect(output).toContain('may overflow in the browser');
+  });
+
+  test('does not warn on slide with overflow lines when comment overflow: split is used', async () => {
+    await validateCommand(overflowSplitCommentMd, { logLevel: 'info' });
+    const output = logSpy.mock.calls.map((c: any) => c[0]).join('\n');
+    expect(output).not.toContain('may overflow in the browser');
+  });
+
+  test('does not warn on slide with overflow lines when frontmatter overflow: split is used', async () => {
+    await validateCommand(overflowSplitMetaMd, { logLevel: 'info' });
+    const output = logSpy.mock.calls.map((c: any) => c[0]).join('\n');
+    expect(output).not.toContain('may overflow in the browser');
   });
 });

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,136 @@
+# @mindfiredigital/mdslide-core
+
+The core compilation, normalization, and rendering engine for `mdslide`. It orchestrates the transformation of a parsed Markdown AST into interactive, styled slide decks.
+
+## 🏗 Compiler Architecture & Pipeline Flow
+
+The compilation process is managed by the central `Compiler` class and flows through the following pipeline:
+
+```mermaid
+flowchart TD
+    A[Markdown Input] --> B[YAML Parser]
+    B -->|Content| C[Parser & Lexer]
+    C -->|Raw Slide Blocks| D[AST Normalizer]
+    D -->|Slide-Level Properties| E[Layout/Split Transformer]
+    E -->|Structured AST| F[Overflow Engine]
+    F -->|Budget-Normalized AST| G[HTML/Theme Engine]
+    G --> H[Final Web presentation HTML]
+```
+
+---
+
+## 📦 Key Core Modules
+
+### 1. Parser & Lexer (`src/parser/`)
+
+Translates raw Markdown source string into slide chunks. Slicing boundaries are detected using a three-phase boundary resolution model:
+
+- **Phase 1 (Explicit Dividers)**: Identifies thematic breaks (`---`) or level-2 headings (`##`) to split slides.
+- **Phase 2 (Heading Boundaries)**: If no explicit dividers exist, it splits the document at every major header level H1 (`#`) or H3 (`###`).
+- **Phase 3 (Fallback Budget Chunking)**: If the document is flat text with no headers or dividers, it accumulates node layout weights until it crosses `MAX_SLIDE_SCORE` (100) and splits to maintain legibility.
+
+### 2. Normalizer & Metadata Extractor (`src/normalizer/`)
+
+Translates standard MDAST nodes into custom Slide AST representations. It parses and filters slide configurations declared in HTML comments:
+
+- **Layout Overrides**: `<!-- layout: type -->` overrides layout classification (`title`, `bullets`, `code`, `visual`, `table`, `quote`, `statement`, `split`).
+- **Background Images**: `<!-- backgroundImage: url('...') [dark|light] -->` mounts custom backgrounds.
+- **Title Positioning**: `<!-- titleAlign: center -->` (horizontal alignment) and `<!-- titlePosition: bottom -->` (vertical alignment) are normalized and appended to slide data attributes.
+- **Speaker Notes**: Text inside `<!-- notes -->...<!-- /notes -->` is extracted as slide notes.
+
+### 3. Layout & Column Transformer (`src/transformers/`)
+
+Handles advanced multi-column transformations:
+
+- **Manual Splits (`::split::`)**: Locates the `::split::` separator block, groups nodes on the left and right, wraps them in column sub-containers, and applies the `split` layout.
+- **Auto-Splits**: If a slide contains exactly one image alongside text, the engine automatically splits them into a two-column layout (text on left, image on right). If a slide contains only an image, it transforms it to a full-screen `visual` layout.
+
+### 4. Visual Overflow Engine (`src/overflow/`)
+
+To prevent contents from bleeding out of the viewport, the overflow engine calculates the vertical size of each node in pixels:
+
+- **Height Heuristics**:
+  - Code Block: `50px` header + `24px * number of lines`.
+  - Table: `35px` header + `38px * number of rows`.
+  - Bullet List Item: text wrapping count (evaluated at 55 chars per line) \* `30px` + `10px` margin.
+  - Image: `350px`.
+  - Paragraph: text wrap count (at 65 chars/line) \* `30px` + `15px`.
+  - Headings: H1: wrap count _ `65px` + `20px`; H2/H3: wrap count _ `45px` + `15px`.
+- **Splitting Rules**: If the total height exceeds `680px`, it splits lists and code blocks. Remaining items are pushed onto a new continuation slide, retaining the parent settings and appending `(Cont.)` to the title.
+
+### 5. Theme Engine (`src/themes/`)
+
+Injects styling systems:
+
+- Resolves base styles (like 1080p slide margins, transitions, and docks) and integrates custom CSS variables for predefined themes (`light`, `dark`, `notion`, `terminal`, `gradient`, `corporate`, `solarized`).
+
+---
+
+## ✍️ Slide Syntax Quick Reference
+
+### Frontmatter (Global)
+
+```yaml
+---
+title: Presentation Title
+theme: corporate
+titleAlign: center
+titlePosition: top
+---
+```
+
+### Column Splitting (`::split::`)
+
+```markdown
+# Multi-Column Layout
+
+Left column points:
+
+- Bullet item 1
+- Bullet item 2
+
+::split::
+
+Right column points:
+
+- Bullet item 3
+- Bullet item 4
+```
+
+### Overrides (Local Slide Comments)
+
+```markdown
+<!-- layout: quote -->
+<!-- titleAlign: right -->
+<!-- titlePosition: bottom -->
+<!-- backgroundImage: url('background.png') dark -->
+
+<!-- notes -->
+
+Speaker notes for Presenter View console window.
+
+<!-- /notes -->
+```
+
+---
+
+## 🛠 Programmatic Usage
+
+You can invoke the compiler programmatically by importing the `Compiler` class:
+
+```typescript
+import { Compiler } from '@mindfiredigital/mdslide-core';
+
+const compiler = new Compiler();
+const result = compiler.compile(
+  `# Slide 1
+Content
+---
+# Slide 2`,
+  { theme: 'gradient' }
+);
+
+console.log(result.html); // Output standalone presentation HTML
+console.log(result.slides); // Output normalized AST array
+console.log(result.meta); // Output parsed frontmatter metadata
+```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,9 +24,11 @@
     "@mindfiredigital/mdslide-parser": "workspace:*",
     "@mindfiredigital/mdslide-shared": "workspace:*",
     "gray-matter": "^4.0.3",
+    "katex": "^0.16.9",
     "mdast-util-to-string": "^4.0.0"
   },
   "devDependencies": {
+    "@types/katex": "^0.16.7",
     "@types/mdast": "^4.0.4",
     "@types/node": "^25.6.0",
     "tsup": "^8.0.0"

--- a/packages/core/src/ast/createSlideNode.ts
+++ b/packages/core/src/ast/createSlideNode.ts
@@ -27,5 +27,6 @@ export function createSlide(partial: Partial<Slide>): Slide {
     backgroundImage: partial.backgroundImage,
     titleAlign: partial.titleAlign,
     titlePosition: partial.titlePosition,
+    overflow: partial.overflow,
   };
 }

--- a/packages/core/src/ast/createSlideNode.ts
+++ b/packages/core/src/ast/createSlideNode.ts
@@ -23,5 +23,6 @@ export function createSlide(partial: Partial<Slide>): Slide {
     notes: partial.notes,
     title: partial.title,
     layoutOverride: partial.layoutOverride,
+    backgroundImage: partial.backgroundImage,
   };
 }

--- a/packages/core/src/ast/createSlideNode.ts
+++ b/packages/core/src/ast/createSlideNode.ts
@@ -11,6 +11,7 @@ export function createSlideNode(partial: Partial<SlideNode> & { type: string }):
     url: partial.url,
     alt: partial.alt,
     header: partial.header,
+    depth: partial.depth,
   };
 }
 
@@ -24,5 +25,7 @@ export function createSlide(partial: Partial<Slide>): Slide {
     title: partial.title,
     layoutOverride: partial.layoutOverride,
     backgroundImage: partial.backgroundImage,
+    titleAlign: partial.titleAlign,
+    titlePosition: partial.titlePosition,
   };
 }

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -40,6 +40,7 @@ export const SUPPORTED_LANGS = [
   'sql',
   'yaml',
   'yml',
+  'mermaid',
 ];
 
 export const DEFAULT_TITLE = 'Presentation';

--- a/packages/core/src/normalizer/mdAstToSlideBasedAst.ts
+++ b/packages/core/src/normalizer/mdAstToSlideBasedAst.ts
@@ -5,7 +5,12 @@ import { RawSlideBlock } from '../interfaces/index.js';
 import { isHeading } from '../parser/index.js';
 import { normalizeHeading } from './normalizeHeading.js';
 import { extractSlideNotes } from './normalizeNote.js';
-import { parseLayoutOveride, resolveSlideLayout, parseBackgroundImage } from './normalizeLayout.js';
+import {
+  parseLayoutOveride,
+  resolveSlideLayout,
+  parseBackgroundImage,
+  parseTitlePositioning,
+} from './normalizeLayout.js';
 
 // Converts generic MDAST node into Slide AST Node
 export function toSlideAstNode(node: RootContent, isTableHeader = false): SlideNode {
@@ -39,6 +44,7 @@ export function toSlideAstNode(node: RootContent, isTableHeader = false): SlideN
     url: 'url' in node ? String(node.url) : undefined,
     alt: 'alt' in node ? String(node.alt) : undefined,
     header: isTableHeader || ('header' in node ? Boolean(node.header) : undefined),
+    depth: 'depth' in node ? Number(node.depth) : undefined,
   });
 }
 
@@ -51,22 +57,32 @@ export function normalizeSlide(rawBlock: RawSlideBlock): Slide {
   const { backgroundImage, filteredNodes: nodesWithoutBg } =
     parseBackgroundImage(nodesWithoutLayout);
 
+  const {
+    titleAlign,
+    titlePosition,
+    filteredNodes: nodesWithoutPos,
+  } = parseTitlePositioning(nodesWithoutBg);
+
   let slideTitle: string | undefined;
   const slideContent: SlideNode[] = [];
 
-  for (const node of nodesWithoutBg) {
+  for (const node of nodesWithoutPos) {
     if (isHeading(node)) {
       const headingNode = node as Heading;
       const normalized = normalizeHeading(headingNode);
 
       if (headingNode.depth === 1) {
-        slideTitle = normalized.text;
-        continue;
+        if (!slideTitle) {
+          slideTitle = normalized.text;
+          continue;
+        }
       }
 
       if (headingNode.depth === 2) {
-        slideTitle = slideTitle ?? normalized.text;
-        continue;
+        if (!slideTitle) {
+          slideTitle = normalized.text;
+          continue;
+        }
       }
     }
 
@@ -83,9 +99,36 @@ export function normalizeSlide(rawBlock: RawSlideBlock): Slide {
     notes,
     layoutOverride,
     backgroundImage,
+    titleAlign,
+    titlePosition,
   });
 }
 
-export function normalizeSlides(rawBlocks: RawSlideBlock[]): Slide[] {
-  return rawBlocks.map(normalizeSlide).filter((s) => s.title !== undefined || s.content.length > 0);
+export function normalizeSlides(
+  rawBlocks: RawSlideBlock[],
+  meta?: Record<string, unknown>
+): Slide[] {
+  return rawBlocks
+    .map((rawBlock) => {
+      const slide = normalizeSlide(rawBlock);
+      if (meta) {
+        const align = meta.titleAlign ?? meta.titlealign;
+        if (align && !slide.titleAlign) {
+          slide.titleAlign = String(align).toLowerCase();
+        }
+        const position = meta.titlePosition ?? meta.titleposition;
+        if (position && !slide.titlePosition) {
+          const pos = String(position).toLowerCase();
+          if (pos === 'buttom') {
+            slide.titlePosition = 'bottom';
+          } else if (pos === 'middle') {
+            slide.titlePosition = 'center';
+          } else {
+            slide.titlePosition = pos;
+          }
+        }
+      }
+      return slide;
+    })
+    .filter((s) => s.title !== undefined || s.content.length > 0);
 }

--- a/packages/core/src/normalizer/mdAstToSlideBasedAst.ts
+++ b/packages/core/src/normalizer/mdAstToSlideBasedAst.ts
@@ -10,6 +10,7 @@ import {
   resolveSlideLayout,
   parseBackgroundImage,
   parseTitlePositioning,
+  parseOverflowConfig,
 } from './normalizeLayout.js';
 
 // Converts generic MDAST node into Slide AST Node
@@ -63,10 +64,12 @@ export function normalizeSlide(rawBlock: RawSlideBlock): Slide {
     filteredNodes: nodesWithoutPos,
   } = parseTitlePositioning(nodesWithoutBg);
 
+  const { overflow, filteredNodes: nodesWithoutOverflow } = parseOverflowConfig(nodesWithoutPos);
+
   let slideTitle: string | undefined;
   const slideContent: SlideNode[] = [];
 
-  for (const node of nodesWithoutPos) {
+  for (const node of nodesWithoutOverflow) {
     if (isHeading(node)) {
       const headingNode = node as Heading;
       const normalized = normalizeHeading(headingNode);
@@ -101,6 +104,7 @@ export function normalizeSlide(rawBlock: RawSlideBlock): Slide {
     backgroundImage,
     titleAlign,
     titlePosition,
+    overflow,
   });
 }
 
@@ -126,6 +130,10 @@ export function normalizeSlides(
           } else {
             slide.titlePosition = pos;
           }
+        }
+        const overflow = meta.overflow;
+        if (overflow && !slide.overflow) {
+          slide.overflow = String(overflow).toLowerCase();
         }
       }
       return slide;

--- a/packages/core/src/normalizer/mdAstToSlideBasedAst.ts
+++ b/packages/core/src/normalizer/mdAstToSlideBasedAst.ts
@@ -5,7 +5,7 @@ import { RawSlideBlock } from '../interfaces/index.js';
 import { isHeading } from '../parser/index.js';
 import { normalizeHeading } from './normalizeHeading.js';
 import { extractSlideNotes } from './normalizeNote.js';
-import { parseLayoutOveride, resolveSlideLayout } from './normalizeLayout.js';
+import { parseLayoutOveride, resolveSlideLayout, parseBackgroundImage } from './normalizeLayout.js';
 
 // Converts generic MDAST node into Slide AST Node
 export function toSlideAstNode(node: RootContent, isTableHeader = false): SlideNode {
@@ -48,10 +48,13 @@ export function normalizeSlide(rawBlock: RawSlideBlock): Slide {
   const { layoutOverride, filteredNodes: nodesWithoutLayout } =
     parseLayoutOveride(nodesWithoutNotes);
 
+  const { backgroundImage, filteredNodes: nodesWithoutBg } =
+    parseBackgroundImage(nodesWithoutLayout);
+
   let slideTitle: string | undefined;
   const slideContent: SlideNode[] = [];
 
-  for (const node of nodesWithoutLayout) {
+  for (const node of nodesWithoutBg) {
     if (isHeading(node)) {
       const headingNode = node as Heading;
       const normalized = normalizeHeading(headingNode);
@@ -79,6 +82,7 @@ export function normalizeSlide(rawBlock: RawSlideBlock): Slide {
     content: slideContent,
     notes,
     layoutOverride,
+    backgroundImage,
   });
 }
 

--- a/packages/core/src/normalizer/normalizeLayout.ts
+++ b/packages/core/src/normalizer/normalizeLayout.ts
@@ -95,6 +95,30 @@ export function parseTitlePositioning(nodes: RootContent[]): {
   };
 }
 
+export function parseOverflowConfig(nodes: RootContent[]): {
+  overflow: string | undefined;
+  filteredNodes: RootContent[];
+} {
+  let overflow: string | undefined;
+  const filteredNodes: RootContent[] = [];
+
+  for (const node of nodes) {
+    if (node.type === 'html') {
+      const val = node.value.trim();
+      const overflowMatch = val.match(/^<!--\s*overflow:\s*(\w+)\s*-->$/i);
+      if (overflowMatch) {
+        overflow = overflowMatch[1].toLowerCase();
+        continue;
+      }
+    }
+    filteredNodes.push(node);
+  }
+  return {
+    overflow,
+    filteredNodes,
+  };
+}
+
 export function resolveSlideLayout(
   nodes: SlideNode[],
   hasTitle: boolean,

--- a/packages/core/src/normalizer/normalizeLayout.ts
+++ b/packages/core/src/normalizer/normalizeLayout.ts
@@ -27,6 +27,35 @@ export function parseLayoutOveride(nodes: RootContent[]): {
   };
 }
 
+export function parseBackgroundImage(nodes: RootContent[]): {
+  backgroundImage: string | undefined;
+  filteredNodes: RootContent[];
+} {
+  let backgroundImage: string | undefined;
+  const filteredNodes: RootContent[] = [];
+
+  for (const node of nodes) {
+    if (node.type === 'html') {
+      const val = node.value.trim();
+      const bgMatch = val.match(/^<!--\s*background-?image:\s*(.+?)\s*-->$/i);
+      if (bgMatch) {
+        let bgUrl = bgMatch[1].trim();
+        const urlWrapMatch = bgUrl.match(/^url\((['"]?)(.+?)\1\)$/i);
+        if (urlWrapMatch) {
+          bgUrl = urlWrapMatch[2];
+        }
+        backgroundImage = bgUrl;
+        continue;
+      }
+    }
+    filteredNodes.push(node);
+  }
+  return {
+    backgroundImage,
+    filteredNodes,
+  };
+}
+
 export function resolveSlideLayout(
   nodes: SlideNode[],
   hasTitle: boolean,

--- a/packages/core/src/normalizer/normalizeLayout.ts
+++ b/packages/core/src/normalizer/normalizeLayout.ts
@@ -56,6 +56,45 @@ export function parseBackgroundImage(nodes: RootContent[]): {
   };
 }
 
+export function parseTitlePositioning(nodes: RootContent[]): {
+  titleAlign: string | undefined;
+  titlePosition: string | undefined;
+  filteredNodes: RootContent[];
+} {
+  let titleAlign: string | undefined;
+  let titlePosition: string | undefined;
+  const filteredNodes: RootContent[] = [];
+
+  for (const node of nodes) {
+    if (node.type === 'html') {
+      const val = node.value.trim();
+      const alignMatch = val.match(/^<!--\s*titleAlign:\s*(\w+)\s*-->$/i);
+      if (alignMatch) {
+        titleAlign = alignMatch[1].toLowerCase();
+        continue;
+      }
+      const positionMatch = val.match(/^<!--\s*titlePosition:\s*(\w+)\s*-->$/i);
+      if (positionMatch) {
+        const pos = positionMatch[1].toLowerCase();
+        if (pos === 'buttom') {
+          titlePosition = 'bottom';
+        } else if (pos === 'middle') {
+          titlePosition = 'center';
+        } else {
+          titlePosition = pos;
+        }
+        continue;
+      }
+    }
+    filteredNodes.push(node);
+  }
+  return {
+    titleAlign,
+    titlePosition,
+    filteredNodes,
+  };
+}
+
 export function resolveSlideLayout(
   nodes: SlideNode[],
   hasTitle: boolean,

--- a/packages/core/src/overflow/index.ts
+++ b/packages/core/src/overflow/index.ts
@@ -7,26 +7,40 @@ function calculateNodeHeight(node: SlideNode): number {
 
   if (node.type === 'code') {
     const lines = (node.value || '').split('\n').length;
-    baseHeight = 40 + lines * 16;
+    baseHeight = 50 + lines * 24;
   } else if (node.type === 'table') {
     const rows = node.children ? node.children.length : 0;
-    baseHeight = 20 + rows * 26;
+    baseHeight = 35 + rows * 38;
   } else if (node.type === 'list') {
     baseHeight = 15;
   } else if (node.type === 'listItem') {
     const textLen = extractTextLength(node);
-    const wrapLines = Math.ceil(textLen / 70);
-    baseHeight = Math.max(22, wrapLines * 20);
+    const wrapLines = Math.ceil(textLen / 55);
+    baseHeight = Math.max(30, wrapLines * 30) + 10;
   } else if (node.type === 'image') {
-    baseHeight = 300;
+    baseHeight = 350;
   } else if (node.type === 'blockquote') {
     const textLen = extractTextLength(node);
-    const wrapLines = Math.ceil(textLen / 75);
-    baseHeight = 20 + wrapLines * 20;
+    const wrapLines = Math.ceil(textLen / 65);
+    baseHeight = 25 + wrapLines * 30 + 15;
+  } else if (node.type === 'heading') {
+    const depth = (node as any).depth || 1;
+    const textLen = extractTextLength(node);
+    if (depth === 1) {
+      const wrapLines = Math.ceil(textLen / 40);
+      baseHeight = wrapLines * 65 + 20;
+    } else {
+      const wrapLines = Math.ceil(textLen / 50);
+      baseHeight = wrapLines * 45 + 15;
+    }
+  } else if (node.type === 'paragraph') {
+    const textLen = extractTextLength(node);
+    const wrapLines = Math.ceil(textLen / 65);
+    baseHeight = wrapLines * 30 + 15;
   } else {
     const textLen = extractTextLength(node);
-    const wrapLines = Math.ceil(textLen / 80);
-    baseHeight = wrapLines * 20 + 8;
+    const wrapLines = Math.ceil(textLen / 70);
+    baseHeight = wrapLines * 30 + 10;
   }
 
   if (node.children && node.type !== 'table') {
@@ -40,6 +54,12 @@ function calculateNodeHeight(node: SlideNode): number {
         child.type === 'code' ||
         child.type === 'table'
       ) {
+        if (
+          child.type === 'paragraph' &&
+          (node.type === 'listItem' || node.type === 'blockquote')
+        ) {
+          continue;
+        }
         baseHeight += calculateNodeHeight(child);
       }
     }
@@ -81,6 +101,8 @@ export function processOverflow(slides: Slide[]): Slide[] {
         notes: isContinuation ? undefined : slide.notes,
         layoutOverride: slide.layoutOverride,
         backgroundImage: slide.backgroundImage,
+        titleAlign: slide.titleAlign,
+        titlePosition: slide.titlePosition,
       });
 
       continuationCount++;
@@ -137,7 +159,7 @@ export function processOverflow(slides: Slide[]): Slide[] {
           if (
             fitChildren.length > 0 &&
             splitIndex !== -1 &&
-            children.length - fitChildren.length > 3
+            children.length - fitChildren.length >= 1
           ) {
             remainChildren = children.slice(splitIndex);
             currentSlideContent.push({ ...node, children: fitChildren });
@@ -186,6 +208,8 @@ export function processOverflow(slides: Slide[]): Slide[] {
         notes: isContinuation ? undefined : slide.notes,
         layoutOverride: slide.layoutOverride,
         backgroundImage: slide.backgroundImage,
+        titleAlign: slide.titleAlign,
+        titlePosition: slide.titlePosition,
       });
     }
   }

--- a/packages/core/src/overflow/index.ts
+++ b/packages/core/src/overflow/index.ts
@@ -81,6 +81,11 @@ export function processOverflow(slides: Slide[]): Slide[] {
       continue;
     }
 
+    if (slide.overflow !== 'split') {
+      resultSlides.push(slide);
+      continue;
+    }
+
     let currentSlideContent: SlideNode[] = [];
     let currentHeight = 0;
     let continuationCount = 0;
@@ -103,6 +108,7 @@ export function processOverflow(slides: Slide[]): Slide[] {
         backgroundImage: slide.backgroundImage,
         titleAlign: slide.titleAlign,
         titlePosition: slide.titlePosition,
+        overflow: slide.overflow,
       });
 
       continuationCount++;
@@ -210,6 +216,7 @@ export function processOverflow(slides: Slide[]): Slide[] {
         backgroundImage: slide.backgroundImage,
         titleAlign: slide.titleAlign,
         titlePosition: slide.titlePosition,
+        overflow: slide.overflow,
       });
     }
   }

--- a/packages/core/src/overflow/index.ts
+++ b/packages/core/src/overflow/index.ts
@@ -80,6 +80,7 @@ export function processOverflow(slides: Slide[]): Slide[] {
         content: currentSlideContent,
         notes: isContinuation ? undefined : slide.notes,
         layoutOverride: slide.layoutOverride,
+        backgroundImage: slide.backgroundImage,
       });
 
       continuationCount++;
@@ -99,7 +100,7 @@ export function processOverflow(slides: Slide[]): Slide[] {
           continue;
         }
 
-        if (node.type === 'code' && availableHeight > 100) {
+        if (node.type === 'code' && node.lang !== 'mermaid' && availableHeight > 100) {
           const lines = (node.value || '').split('\n');
           const maxLines = Math.floor((availableHeight - 40) / 16);
 
@@ -184,6 +185,7 @@ export function processOverflow(slides: Slide[]): Slide[] {
         content: currentSlideContent,
         notes: isContinuation ? undefined : slide.notes,
         layoutOverride: slide.layoutOverride,
+        backgroundImage: slide.backgroundImage,
       });
     }
   }

--- a/packages/core/src/parser/markdownParser.ts
+++ b/packages/core/src/parser/markdownParser.ts
@@ -1,5 +1,6 @@
 import { parseMarkdownToAST } from '@mindfiredigital/mdslide-parser';
 import type { Root, RootContent } from 'mdast';
+import { randomUUID } from 'node:crypto';
 import type { RawSlideBlock, ParseMarkdownResult } from '../interfaces/index.js';
 import { isThematicBreak, isHeading } from './lexer.js';
 import { MAX_SLIDE_SCORE } from '../constants/index.js';
@@ -29,7 +30,7 @@ export function parseMarkdown(markdown: string): ParseMarkdownResult {
       const pushSlide = () => {
         if (currentNodes.length > 0) {
           slides.push({
-            id: globalThis.crypto.randomUUID(),
+            id: randomUUID(),
             nodes: currentNodes,
           });
           currentNodes = [];
@@ -65,7 +66,7 @@ export function parseMarkdown(markdown: string): ParseMarkdownResult {
         const pushSlide = () => {
           if (currentNodes.length > 0) {
             slides.push({
-              id: globalThis.crypto.randomUUID(),
+              id: randomUUID(),
               nodes: currentNodes,
             });
             currentNodes = [];
@@ -93,7 +94,7 @@ export function parseMarkdown(markdown: string): ParseMarkdownResult {
         const pushSlide = () => {
           if (currentNodes.length > 0) {
             slides.push({
-              id: globalThis.crypto.randomUUID(),
+              id: randomUUID(),
               nodes: currentNodes,
             });
 

--- a/packages/core/src/parser/markdownParser.ts
+++ b/packages/core/src/parser/markdownParser.ts
@@ -43,7 +43,9 @@ export function parseMarkdown(markdown: string): ParseMarkdownResult {
         }
 
         if (isHeading(node) && 'depth' in node && node.depth === 2 && currentNodes.length > 0) {
-          pushSlide();
+          if (!hasThematicBreak) {
+            pushSlide();
+          }
         }
 
         currentNodes.push(node);

--- a/packages/core/src/pipeline/compiler.ts
+++ b/packages/core/src/pipeline/compiler.ts
@@ -32,7 +32,7 @@ export class Compiler {
     const { slides: rawBlocks } = parseMarkdown(content);
 
     // Transform generic MDAST slide blocks to presentation Slide AST
-    const normalizedSlides = normalizeSlides(rawBlocks);
+    const normalizedSlides = normalizeSlides(rawBlocks, meta);
 
     // Run AST transforms
     const transformedSlides = runTransforms(normalizedSlides);

--- a/packages/core/src/renderer/html/index.ts
+++ b/packages/core/src/renderer/html/index.ts
@@ -97,7 +97,52 @@ export function renderDeck(deck: SlideDeck, options: RenderDeckOptions = {}): st
       height: auto !important;
     }
 
-    
+    .bgImageDark,
+    .bgImageDark p,
+    .bgImageDark li,
+    .bgImageDark h1,
+    .bgImageDark h2,
+    .bgImageDark h3,
+    .bgImageDark h4,
+    .bgImageDark h5,
+    .bgImageDark h6,
+    .bgImageDark span,
+    .bgImageDark strong,
+    .bgImageDark em,
+    .bgImageDark td,
+    .bgImageDark th {
+      color: #fafafa !important;
+      -webkit-text-fill-color: #fafafa !important;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.8), 0 0 10px rgba(0,0,0,0.5) !important;
+    }
+    .bgImageDark blockquote {
+      border-left-color: rgba(255,255,255,0.4) !important;
+      background: rgba(0,0,0,0.3) !important;
+    }
+
+    .bgImageLight,
+    .bgImageLight p,
+    .bgImageLight li,
+    .bgImageLight h1,
+    .bgImageLight h2,
+    .bgImageLight h3,
+    .bgImageLight h4,
+    .bgImageLight h5,
+    .bgImageLight h6,
+    .bgImageLight span,
+    .bgImageLight strong,
+    .bgImageLight em,
+    .bgImageLight td,
+    .bgImageLight th {
+      color: #18181b !important;
+      -webkit-text-fill-color: #18181b !important;
+      text-shadow: 0 1px 2px rgba(255,255,255,0.8) !important;
+    }
+    .bgImageLight blockquote {
+      border-left-color: rgba(0,0,0,0.2) !important;
+      background: rgba(255,255,255,0.3) !important;
+    }
+
     @media print {
       @page {
         size: 1920px 1080px;

--- a/packages/core/src/renderer/html/index.ts
+++ b/packages/core/src/renderer/html/index.ts
@@ -82,6 +82,22 @@ export function renderDeck(deck: SlideDeck, options: RenderDeckOptions = {}): st
       border-right: 1px solid rgba(255,255,255,0.15) !important;
     }
 
+    .mermaid {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 100%;
+      margin: 1.5rem 0;
+      background: transparent !important;
+    }
+
+    .mermaid svg {
+      max-width: 100% !important;
+      max-height: 55vh !important;
+      height: auto !important;
+    }
+
+    
     @media print {
       @page {
         size: 1920px 1080px;
@@ -153,6 +169,17 @@ ${slidesHtml}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+  <!-- Mermaid Support -->
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+    mermaid.initialize({
+      startOnLoad: true,
+      theme: document.documentElement.getAttribute('data-theme') === 'dark' || 
+             document.documentElement.getAttribute('data-theme') === 'terminal' ||
+             document.documentElement.getAttribute('data-theme') === 'gradient'
+             ? 'dark' : 'default'
+    });
+  </script>
   ${script}
 </body>
 </html>`;

--- a/packages/core/src/renderer/html/index.ts
+++ b/packages/core/src/renderer/html/index.ts
@@ -29,6 +29,7 @@ export function renderDeck(deck: SlideDeck, options: RenderDeckOptions = {}): st
   <style id="mdslideTheme">${themeEngine.resolveTheme(theme)}</style>
   <link rel="stylesheet" href="${prismThemeUrl}" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.9/katex.min.css" />
   <style>
     /* Custom Prism overrides to match slide styling perfectly */
     pre[class*="language-"] {

--- a/packages/core/src/renderer/html/index.ts
+++ b/packages/core/src/renderer/html/index.ts
@@ -15,9 +15,21 @@ export function renderDeck(deck: SlideDeck, options: RenderDeckOptions = {}): st
   const slidesHtml = deck.slides.map(renderSlide).join('\n');
 
   const isDarkTheme = ['dark', 'terminal', 'gradient'].includes(theme);
-  const prismThemeUrl = isDarkTheme
-    ? 'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css'
-    : 'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css';
+
+  const urls = {
+    prismCss: isDarkTheme
+      ? 'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css'
+      : 'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism.min.css',
+    prismLineNumbersCss:
+      'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.css',
+    katexCss: 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.9/katex.min.css',
+    prismCoreJs: 'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js',
+    prismAutoloaderJs:
+      'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js',
+    prismLineNumbersJs:
+      'https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.js',
+    mermaidJs: 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs',
+  };
 
   return `<!DOCTYPE html>
 <html lang="en" data-theme="${sanitizeHtml(theme)}">
@@ -27,9 +39,9 @@ export function renderDeck(deck: SlideDeck, options: RenderDeckOptions = {}): st
   <title>${sanitizeHtml(title)}</title>
   <style id="mdslideBase">${themeEngine.getBaseCSS()}</style>
   <style id="mdslideTheme">${themeEngine.resolveTheme(theme)}</style>
-  <link rel="stylesheet" href="${prismThemeUrl}" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.9/katex.min.css" />
+  <link rel="stylesheet" href="${urls.prismCss}" />
+  <link rel="stylesheet" href="${urls.prismLineNumbersCss}" />
+  <link rel="stylesheet" href="${urls.katexCss}" />
   <style>
     /* Custom Prism overrides to match slide styling perfectly */
     pre[class*="language-"] {
@@ -211,12 +223,12 @@ ${slidesHtml}
     </button>
   </div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+  <script src="${urls.prismCoreJs}"></script>
+  <script src="${urls.prismAutoloaderJs}"></script>
+  <script src="${urls.prismLineNumbersJs}"></script>
   <!-- Mermaid Support -->
   <script type="module">
-    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+    import mermaid from '${urls.mermaidJs}';
     mermaid.initialize({
       startOnLoad: true,
       theme: document.documentElement.getAttribute('data-theme') === 'dark' || 

--- a/packages/core/src/renderer/html/presentorWIndowScript.ts
+++ b/packages/core/src/renderer/html/presentorWIndowScript.ts
@@ -1,32 +1,36 @@
 export const presentorWindowScript = `
-
 function scalePreviews() {
   const currContainer = document
     .getElementById('current-panel')
     .querySelector('.preview-container');
   const nextContainer = document.getElementById('next-panel').querySelector('.preview-container');
-
   const currPreview = document.getElementById('current-preview');
   const nextPreview = document.getElementById('next-preview');
-
   if (currContainer && currPreview) {
     const w = currContainer.clientWidth;
     const h = currContainer.clientHeight;
     const scale = Math.min(w / 1920, h / 1080);
+    const left = (w - 1920 * scale) / 2;
+    const top = (h - 1080 * scale) / 2;
+    currPreview.style.transformOrigin = 'top left';
     currPreview.style.transform = 'scale(' + scale + ')';
+    currPreview.style.left = left + 'px';
+    currPreview.style.top = top + 'px';
   }
-
   if (nextContainer && nextPreview) {
     const w = nextContainer.clientWidth;
     const h = nextContainer.clientHeight;
     const scale = Math.min(w / 1920, h / 1080);
+    const left = (w - 1920 * scale) / 2;
+    const top = (h - 1080 * scale) / 2;
+    nextPreview.style.transformOrigin = 'top left';
     nextPreview.style.transform = 'scale(' + scale + ')';
+    nextPreview.style.left = left + 'px';
+    nextPreview.style.top = top + 'px';
   }
 }
-
 window.scalePreviews = scalePreviews;
 window.addEventListener('resize', scalePreviews);
-
 // Forward keyboard navigation to main window
 window.addEventListener('keydown', function (e) {
   if (e.key === 'ArrowRight' || e.key === ' ') {
@@ -37,9 +41,6 @@ window.addEventListener('keydown', function (e) {
     window.opener.postMessage('togglePresenter', '*');
   }
 });
-
 // Run initial scaling
 setTimeout(scalePreviews, 100);
-
-
 `;

--- a/packages/core/src/renderer/html/renderCode.ts
+++ b/packages/core/src/renderer/html/renderCode.ts
@@ -6,6 +6,10 @@ export function renderCodeBlock(node: SlideNode): string {
   const lang = (node.lang ?? '').toLowerCase();
   const value = node.value ?? '';
 
+  if (lang === 'mermaid') {
+    return `<div class="mermaid">${sanitizeHtml(value)}</div>`;
+  }
+
   if (lang && SUPPORTED_LANGS.includes(lang)) {
     return `<pre class="lineNumbers language-${sanitizeHtml(lang)}"><code class="language-${sanitizeHtml(lang)}">${sanitizeHtml(value)}</code></pre>`;
   }

--- a/packages/core/src/renderer/html/renderSlide.ts
+++ b/packages/core/src/renderer/html/renderSlide.ts
@@ -177,10 +177,10 @@ export function nodeToHtml(node: SlideNode): string {
       return '';
 
     case 'math':
-      return `<div class="math math-display">${renderMath(node.value ?? '', true)}</div>`;
+      return `<div class="math mathDisplay">${renderMath(node.value ?? '', true)}</div>`;
 
     case 'inlineMath':
-      return `<span class="math math-inline">${renderMath(node.value ?? '', false)}</span>`;
+      return `<span class="math mathInline">${renderMath(node.value ?? '', false)}</span>`;
 
     case 'column':
       return childrenToHtml(node);

--- a/packages/core/src/renderer/html/renderSlide.ts
+++ b/packages/core/src/renderer/html/renderSlide.ts
@@ -1,7 +1,19 @@
 import type { Slide, SlideNode } from '@mindfiredigital/mdslide-shared';
+import katex from 'katex';
 import { renderCodeBlock, renderInlineCode } from './renderCode.js';
 import { renderTable, renderTableRow, renderTableCell } from './renderTable.js';
 import { sanitizeHtml, sanitizeUrl } from '../../utils/index.js';
+
+function renderMath(formula: string, displayMode: boolean): string {
+  try {
+    return katex.renderToString(formula, {
+      displayMode,
+      throwOnError: false,
+    });
+  } catch (err) {
+    return sanitizeHtml(formula);
+  }
+}
 
 // Extract all image node from tree and return them separately
 function extractImages(nodes: SlideNode[]): {
@@ -164,6 +176,12 @@ export function nodeToHtml(node: SlideNode): string {
       // Strip HTML comments and raw HTML nodes
       return '';
 
+    case 'math':
+      return `<div class="math math-display">${renderMath(node.value ?? '', true)}</div>`;
+
+    case 'inlineMath':
+      return `<span class="math math-inline">${renderMath(node.value ?? '', false)}</span>`;
+
     case 'column':
       return childrenToHtml(node);
 
@@ -254,7 +272,15 @@ export function renderSlide(slide: Slide): string {
     contentHtml = slide.content.map(nodeToHtml).join('\n');
   }
 
-  return `<section class="slide" data-type="${slide.type}" data-id="${slide.id}">
+  let bgAttr = '';
+  let bgStyle = '';
+  if (slide.backgroundImage) {
+    const cleanUrl = slide.backgroundImage.replace(/\s+(dark|light)$/i, '').trim();
+    bgAttr = ` data-background-image="${sanitizeHtml(slide.backgroundImage)}"`;
+    bgStyle = ` style="background-image: url('${sanitizeHtml(cleanUrl)}') !important; background-size: cover !important; background-position: center !important; background-repeat: no-repeat !important;"`;
+  }
+
+  return `<section class="slide"${bgAttr}${bgStyle} data-type="${slide.type}" data-id="${slide.id}">
   ${titleHtml}
   <div class="slideContent">
     ${contentHtml}

--- a/packages/core/src/renderer/html/renderSlide.ts
+++ b/packages/core/src/renderer/html/renderSlide.ts
@@ -4,6 +4,8 @@ import { renderCodeBlock, renderInlineCode } from './renderCode.js';
 import { renderTable, renderTableRow, renderTableCell } from './renderTable.js';
 import { sanitizeHtml, sanitizeUrl } from '../../utils/index.js';
 
+let globalFragmentCounter = 0;
+
 function renderMath(formula: string, displayMode: boolean): string {
   try {
     return katex.renderToString(formula, {
@@ -93,6 +95,11 @@ export function nodeToHtml(node: SlideNode): string {
       return `<p>${childrenToHtml(node)}</p>`;
     }
 
+    case 'heading': {
+      const depth = node.depth ?? 3;
+      return `<h${depth}>${childrenToHtml(node)}</h${depth}>`;
+    }
+
     case 'text':
       return sanitizeHtml(node.value ?? '');
 
@@ -124,13 +131,15 @@ export function nodeToHtml(node: SlideNode): string {
       const itemsHtml = (node.children ?? [])
         .map((item) => {
           if (!listItemHasImage(item)) {
-            return `<li>${childrenToHtml(item)}</li>`;
+            globalFragmentCounter++;
+            return `<li class="fragment" id="frag-${globalFragmentCounter}">${childrenToHtml(item)}</li>`;
           }
           // Extract images from this item
           const { clean, images } = extractImages(item.children ?? []);
           collectedImages.push(...images);
           const textContent = clean.map(nodeToHtml).join('');
-          return `<li>${textContent}</li>`;
+          globalFragmentCounter++;
+          return `<li class="fragment" id="frag-${globalFragmentCounter}">${textContent}</li>`;
         })
         .join('');
 
@@ -143,8 +152,10 @@ export function nodeToHtml(node: SlideNode): string {
       return `<${tag}>${itemsHtml}</${tag}>${imagesHtml}`;
     }
 
-    case 'listItem':
-      return `<li>${childrenToHtml(node)}</li>`;
+    case 'listItem': {
+      globalFragmentCounter++;
+      return `<li class="fragment" id="frag-${globalFragmentCounter}">${childrenToHtml(node)}</li>`;
+    }
 
     case 'blockquote':
       return `<blockquote>${childrenToHtml(node)}</blockquote>`;
@@ -152,7 +163,8 @@ export function nodeToHtml(node: SlideNode): string {
     case 'image': {
       const src = node.url ?? node.value ?? '';
       const alt = node.alt ?? '';
-      return `<img src="${sanitizeUrl(src, true)}" alt="${sanitizeHtml(alt)}" loading="lazy" />`;
+      globalFragmentCounter++;
+      return `<img src="${sanitizeUrl(src, true)}" alt="${sanitizeHtml(alt)}" class="fragment" id="frag-${globalFragmentCounter}" loading="lazy" />`;
     }
 
     case 'link': {
@@ -280,7 +292,16 @@ export function renderSlide(slide: Slide): string {
     bgStyle = ` style="background-image: url('${sanitizeHtml(cleanUrl)}') !important; background-size: cover !important; background-position: center !important; background-repeat: no-repeat !important;"`;
   }
 
-  return `<section class="slide"${bgAttr}${bgStyle} data-type="${slide.type}" data-id="${slide.id}">
+  let alignAttr = '';
+  if (slide.titleAlign) {
+    alignAttr = ` data-title-align="${sanitizeHtml(slide.titleAlign)}"`;
+  }
+  let posAttr = '';
+  if (slide.titlePosition) {
+    posAttr = ` data-title-position="${sanitizeHtml(slide.titlePosition)}"`;
+  }
+
+  return `<section class="slide"${bgAttr}${bgStyle}${alignAttr}${posAttr} data-type="${slide.type}" data-id="${slide.id}">
   ${titleHtml}
   <div class="slideContent">
     ${contentHtml}

--- a/packages/core/src/renderer/html/script.ts
+++ b/packages/core/src/renderer/html/script.ts
@@ -19,7 +19,7 @@ export const script = `
       return;
     }
     if (isLightOverridden) {
-      s.classList.add('.bgImageLight');
+      s.classList.add('bgImageLight');
       return;
     }
 
@@ -44,7 +44,7 @@ export const script = `
         if (luminance < 140) {
           s.classList.add('bgImageDark');
         } else {
-          s.classList.add('.bgImageLight');
+          s.classList.add('bgImageLight');
         }
       } catch (e) {
         s.classList.add('bgImageDark');
@@ -55,6 +55,41 @@ export const script = `
     };
   });
 
+  const deck = document.querySelector('.deck');
+
+  function resizeDeck() {
+    if (!deck) return;
+    
+    if (window.matchMedia('print').matches) {
+      deck.style.transform = 'none';
+      deck.style.position = 'relative';
+      deck.style.left = 'auto';
+      deck.style.top = 'auto';
+      deck.style.marginLeft = '0';
+      deck.style.marginTop = '0';
+      return;
+    }
+
+    const width = 1920;
+    const height = 1080;
+    const windowWidth = window.innerWidth;
+    const windowHeight = window.innerHeight;
+
+    const scale = Math.min(windowWidth / width, windowHeight / height);
+
+    deck.style.transform = 'scale(' + scale + ')';
+    deck.style.position = 'absolute';
+    deck.style.left = '50%';
+    deck.style.top = '50%';
+    deck.style.marginLeft = '-' + (width / 2) + 'px';
+    deck.style.marginTop = '-' + (height / 2) + 'px';
+  }
+
+  window.addEventListener('resize', resizeDeck);
+  window.addEventListener('load', resizeDeck);
+  document.addEventListener('DOMContentLoaded', resizeDeck);
+  resizeDeck();
+
   const progressBar = document.getElementById('progressBar');
   const hudCounter = document.getElementById('dokCounter');
   const btnPrev = document.getElementById('dokPrev');
@@ -64,8 +99,10 @@ export const script = `
 
   let current = 0;
   let presenterWindow = null;
+  let activeFragments = [];
+  let currentFragmentIndex = -1;
 
-  function show(index) {
+  function show(index, direction) {
     slides.forEach(function (s, i) {
       const isCurrent = i === index;
       if (isCurrent) {
@@ -103,6 +140,22 @@ export const script = `
       }
     });
 
+    // Update activeFragments for the current slide
+    const currentSlide = slides[index];
+    if (currentSlide) {
+      activeFragments = Array.from(currentSlide.querySelectorAll('.fragment'));
+      if (direction === 'forward') {
+        activeFragments.forEach(function (f) { f.classList.remove('visible'); });
+        currentFragmentIndex = -1;
+      } else if (direction === 'backward') {
+        activeFragments.forEach(function (f) { f.classList.add('visible'); });
+        currentFragmentIndex = activeFragments.length - 1;
+      } else {
+        activeFragments.forEach(function (f) { f.classList.remove('visible'); });
+        currentFragmentIndex = -1;
+      }
+    }
+
     // Update progress bar width
     if (progressBar && slides.length > 0) {
       const progress = ((index + 1) / slides.length) * 100;
@@ -120,14 +173,38 @@ export const script = `
 
   // Hndler of next slide
   function nextSlide() {
-    current = Math.min(current + 1, slides.length - 1);
-    show(current);
+    if (current < slides.length - 1) {
+      current++;
+      show(current, 'forward');
+    }
   }
 
   // Hndler of previous slide
   function prevSlide() {
-    current = Math.max(current - 1, 0);
-    show(current);
+    if (current > 0) {
+      current--;
+      show(current, 'backward');
+    }
+  }
+
+  function triggerNext() {
+    if (currentFragmentIndex < activeFragments.length - 1) {
+      currentFragmentIndex++;
+      activeFragments[currentFragmentIndex].classList.add('visible');
+      updatePresenterContent();
+    } else {
+      nextSlide();
+    }
+  }
+
+  function triggerPrev() {
+    if (currentFragmentIndex >= 0) {
+      activeFragments[currentFragmentIndex].classList.remove('visible');
+      currentFragmentIndex--;
+      updatePresenterContent();
+    } else {
+      prevSlide();
+    }
   }
 
   // Hndler of the full screen toggle
@@ -153,15 +230,19 @@ export const script = `
       .map(function(el) { return el.outerHTML; })
       .join('\\n');
 
+    const theme = document.documentElement.getAttribute('data-theme') || '';
+
     presenterWindow = window.open('', 'mdslide-presenter-' + Date.now(), 'width=1700,height=800');
     if (!presenterWindow) {
       alert('Pop-up blocked! Please allow pop-ups to open the Presenter View.');
       return;
     }
 
-    presenterWindow.document.write(\`
-    ${presentorWindow}
-\`);
+    const presenterHtml = \`${presentorWindow}\`
+      .replace('<html>', '<html data-theme="' + theme + '">')
+      .replace('$' + '{styles}', styles);
+
+    presenterWindow.document.write(presenterHtml);
     presenterWindow.document.close();
 
     // Call update on open
@@ -184,19 +265,58 @@ export const script = `
       clone.classList.remove('past');
       clone.style.transform = 'none';
       clone.style.opacity = '1';
+      clone.style.position = 'relative';
+
+      // Cloned .slide is normally position:absolute inside .deck.
+      // Force the wrapper to a known 1920x1080 box so it doesn't
+      // collapse to 0 height, and so scalePreviews() has something
+      // real to measure/scale.
+      currentPreview.style.position = 'absolute';
+      currentPreview.style.width = '1920px';
+      currentPreview.style.height = '1080px';
+      currentPreview.style.overflow = 'hidden';
+
       currentPreview.innerHTML = '';
       currentPreview.appendChild(clone);
     }
 
     if (nextPreview) {
+      nextPreview.style.position = 'absolute';
+      nextPreview.style.width = '1920px';
+      nextPreview.style.height = '1080px';
+      nextPreview.style.overflow = 'hidden';
+
       if (nextSlide) {
         const clone = nextSlide.cloneNode(true);
         clone.classList.add('active');
         clone.classList.remove('past');
         clone.style.transform = 'none';
         clone.style.opacity = '1';
+        clone.style.position = 'relative';
         nextPreview.innerHTML = '';
         nextPreview.appendChild(clone);
+
+        // Calculate and apply scaling to cloneContent
+        const cloneContent = clone.querySelector('.slideContent');
+        if (cloneContent) {
+          cloneContent.style.transform = 'none';
+          cloneContent.style.width = '100%';
+          cloneContent.style.transformOrigin = 'top left';
+
+          const slideHeight = clone.clientHeight || 1080;
+          const contentHeight = cloneContent.scrollHeight;
+          const title = clone.querySelector('.slideTitle');
+          const titleHeight = title ? title.clientHeight : 0;
+          const availableHeight = slideHeight - titleHeight - 160;
+
+          if (contentHeight > availableHeight && availableHeight > 0) {
+            const scale = availableHeight / contentHeight;
+            if (scale >= 0.7) {
+              cloneContent.style.transform = 'scale(' + scale + ')';
+              cloneContent.style.width = 100 / scale + '%';
+            }
+          }
+        }
       } else {
         nextPreview.innerHTML = '<div class="no-next">End of Presentation</div>';
       }
@@ -219,9 +339,9 @@ export const script = `
   // Handle messages from presenter window
   window.addEventListener('message', function (e) {
     if (e.data === 'next') {
-      nextSlide();
+      triggerNext();
     } else if (e.data === 'prev') {
-      prevSlide();
+      triggerPrev();
     } else if (e.data === 'togglePresenter') {
       togglePresenterWindow();
     }
@@ -230,9 +350,9 @@ export const script = `
   // Navigation of keyBoard
   document.addEventListener('keydown', function (e) {
     if (e.key === 'ArrowRight' || e.key === ' ') {
-      nextSlide();
+      triggerNext();
     } else if (e.key === 'ArrowLeft') {
-      prevSlide();
+      triggerPrev();
     } else if (e.key === 'f') {
       toggleFullscreen();
     } else if (e.key === 'p' || e.key === 'P') {
@@ -241,8 +361,8 @@ export const script = `
   });
 
   // Floating DOK Display Vislibility on Mouse Move
-  if (btnPrev) btnPrev.addEventListener('click', prevSlide);
-  if (btnNext) btnNext.addEventListener('click', nextSlide);
+  if (btnPrev) btnPrev.addEventListener('click', triggerPrev);
+  if (btnNext) btnNext.addEventListener('click', triggerNext);
   if (btnFullscreen) btnFullscreen.addEventListener('click', toggleFullscreen);
   if (btnPresenter) btnPresenter.addEventListener('click', togglePresenterWindow);
 

--- a/packages/core/src/renderer/html/script.ts
+++ b/packages/core/src/renderer/html/script.ts
@@ -5,6 +5,56 @@ export const script = `
 
 (function () {
   const slides = document.querySelectorAll('.slide');
+
+  // Adjust font color for slides with background images
+  slides.forEach(function (s) {
+    const bgUrl = s.getAttribute('data-background-image');
+    if (!bgUrl) return;
+
+    const isDarkOverridden = bgUrl.toLowerCase().includes(' dark');
+    const isLightOverridden = bgUrl.toLowerCase().includes(' light');
+
+    if (isDarkOverridden) {
+      s.classList.add('bgImageDark');
+      return;
+    }
+    if (isLightOverridden) {
+      s.classList.add('.bgImageLight');
+      return;
+    }
+
+    const cleanUrl = bgUrl.replace(/\s+(dark|light)$/i, '').trim();
+
+    const img = new Image();
+    img.crossOrigin = 'Anonymous';
+    img.src = cleanUrl;
+    img.onload = function () {
+      try {
+        const canvas = document.createElement('canvas');
+        canvas.width = 1;
+        canvas.height = 1;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return;
+        ctx.drawImage(img, 0, 0, 1, 1);
+        const data = ctx.getImageData(0, 0, 1, 1).data;
+        const r = data[0];
+        const g = data[1];
+        const b = data[2];
+        const luminance = 0.299 * r + 0.587 * g + 0.114 * b;
+        if (luminance < 140) {
+          s.classList.add('bgImageDark');
+        } else {
+          s.classList.add('.bgImageLight');
+        }
+      } catch (e) {
+        s.classList.add('bgImageDark');
+      }
+    };
+    img.onerror = function () {
+      s.classList.add('bgImageDark');
+    };
+  });
+
   const progressBar = document.getElementById('progressBar');
   const hudCounter = document.getElementById('dokCounter');
   const btnPrev = document.getElementById('dokPrev');

--- a/packages/core/src/themes/presentorWindowCss.ts
+++ b/packages/core/src/themes/presentorWindowCss.ts
@@ -13,6 +13,8 @@ export const presentorWindowCss = `
             gap: 15px;
             box-sizing: border-box;
             overflow: hidden;
+            align-items: stretch;
+            justify-items: stretch;
         }
         .panel {
             border-radius: 10px;
@@ -30,6 +32,7 @@ export const presentorWindowCss = `
             color: #98989d;
             margin-bottom: 10px;
             font-weight: 700;
+            flex-shrink: 0;
         }
         .preview-container {
             flex-grow: 1;

--- a/packages/core/src/themes/themeEngine.ts
+++ b/packages/core/src/themes/themeEngine.ts
@@ -9,12 +9,22 @@ export class ThemeEngine {
     return `
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
+html {
+  font-size: 20px;
+}
+
 body {
   font-family: var(--slide-font, 'Inter', system-ui, sans-serif);
   background: var(--slide-bg);
   color: var(--slide-text);
   height: 100vh;
+  width: 100vw;
+  margin: 0;
+  padding: 0;
   overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
@@ -22,9 +32,15 @@ body {
 
 /* Deck Container */
 .deck {
-  width: 100%;
-  height: 100%;
+  width: 1920px;
+  height: 1080px;
   position: relative;
+  transform-origin: center center;
+  flex-shrink: 0;
+  box-shadow: 0 20px 80px rgba(0, 0, 0, 0.25);
+  background: var(--slide-bg);
+  border-radius: var(--slide-radius, 12px);
+  overflow: hidden;
 }
 
 /* Slide base */
@@ -36,8 +52,8 @@ body {
   justify-content: flex-start;
   align-items: flex-start;
   width: 100%;
-  height: 100vh;
-  padding: 4.5rem 6.5rem;
+  height: 100%;
+  padding: 5.5rem 7.5rem;
   gap: 0;
   opacity: 0;
   pointer-events: none;
@@ -64,24 +80,24 @@ body {
 .slide[data-type="title"] {
   align-items: flex-start;
   justify-content: center;
-  padding: 5rem 7rem;
+  padding: 6.5rem 8.5rem;
 }
 
 .slide[data-type="statement"] {
   align-items: center;
   text-align: center;
   justify-content: center;
-  padding: 5rem 8rem;
+  padding: 6.5rem 9.5rem;
 }
 
 /* Title (h1 / h2 on title slides) */
 .slideTitle {
   font-size: var(--title-size, 3.4rem);
   font-weight: 700;
-  line-height: 1.1;
+  line-height: 1.15;
   letter-spacing: -0.025em;
   color: var(--slide-text);
-  margin-bottom: 2rem;
+  margin-bottom: 2.5rem;
   width: 100%;
   text-align: left;
 }
@@ -91,16 +107,71 @@ body {
   width: 100%;
 }
 
+/* Title Slide positioning/alignment overrides */
+body .slide[data-title-align="left"] {
+  align-items: flex-start !important;
+  text-align: left !important;
+}
+body .slide[data-title-align="left"] .slideTitle {
+  text-align: left !important;
+}
+body .slide[data-title-align="left"] .slideTitle::after {
+  margin-left: 0 !important;
+}
+
+body .slide[data-title-align="center"] {
+  align-items: center !important;
+  text-align: center !important;
+}
+body .slide[data-title-align="center"] .slideTitle {
+  text-align: center !important;
+}
+body .slide[data-title-align="center"] .slideTitle::after {
+  margin-left: auto !important;
+  margin-right: auto !important;
+}
+
+body .slide[data-title-align="right"] {
+  align-items: flex-end !important;
+  text-align: right !important;
+}
+body .slide[data-title-align="right"] .slideTitle {
+  text-align: right !important;
+}
+body .slide[data-title-align="right"] .slideTitle::after {
+  margin-left: auto !important;
+  margin-right: 0 !important;
+}
+
+body .slide[data-title-position="top"] {
+  justify-content: flex-start !important;
+}
+
+body .slide[data-title-position="center"],
+body .slide[data-title-position="middle"] {
+  justify-content: center !important;
+}
+
+body .slide[data-title-position="bottom"] {
+  justify-content: flex-end !important;
+}
+
+body .slide[data-title-position="bottom"] .slideContent,
+body .slide[data-title-position="center"] .slideContent,
+body .slide[data-title-position="middle"] .slideContent {
+  flex: none !important;
+}
+
 /* Content area */
 .slideContent {
   width: 100%;
   flex: 1;
   font-size: var(--body-size, 1.35rem);
-  line-height: 1.7;
+  line-height: 1.8;
   color: var(--slide-text);
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 1.25rem;
   overflow: hidden;
 }
 
@@ -109,39 +180,39 @@ body {
   font-size: var(--title-size, 3.4rem);
   font-weight: 700;
   letter-spacing: -0.025em;
-  line-height: 1.1;
-  margin-bottom: 1.25rem;
+  line-height: 1.15;
+  margin-bottom: 1.75rem;
 }
 
 .slideContent h2 {
-  font-size: var(--h2-size, 2.4rem);
+  font-size: var(--h2-size, 2.6rem);
   font-weight: 700;
   letter-spacing: -0.02em;
-  line-height: 1.15;
-  margin-bottom: 1rem;
+  line-height: 1.2;
+  margin-bottom: 1.5rem;
   color: var(--slide-text);
 }
 
 .slideContent h3 {
-  font-size: var(--h3-size, 1.7rem);
+  font-size: var(--h3-size, 1.8rem);
   font-weight: 600;
   letter-spacing: -0.01em;
-  line-height: 1.2;
-  margin-bottom: 0.75rem;
+  line-height: 1.25;
+  margin-bottom: 1.25rem;
   color: var(--slide-muted);
 }
 
 .slideContent h4, .slideContent h5, .slideContent h6 {
-  font-size: 1.3rem;
+  font-size: 1.4rem;
   font-weight: 600;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.8rem;
 }
 
 /* Paragraph */
 .slideContent p {
   font-size: var(--body-size, 1.35rem);
-  line-height: 1.7;
-  margin-bottom: 0.6rem;
+  line-height: 1.75;
+  margin-bottom: 1rem;
   max-width: 75ch;
 }
 
@@ -155,16 +226,16 @@ body {
 /* Lists */
 .slideContent ul,
 .slideContent ol {
-  padding-left: 1.75rem;
+  padding-left: 2rem;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
-  margin-bottom: 0.5rem;
+  gap: 0.8rem;
+  margin-bottom: 1rem;
 }
 
 .slideContent li {
   font-size: var(--li-size, 1.3rem);
-  line-height: 1.55;
+  line-height: 1.6;
   padding-left: 0.25rem;
 }
 
@@ -179,14 +250,14 @@ body {
 
 /* Blockquote */
 .slideContent blockquote {
-  border-left: 5px solid var(--slide-accent);
-  padding: 1.25rem 2rem;
-  margin: 0.5rem 0;
+  border-left: 6px solid var(--slide-accent);
+  padding: 1.5rem 2.5rem;
+  margin: 1rem 0;
   background: rgba(128,128,128,0.05);
   border-radius: 0 var(--slide-radius) var(--slide-radius) 0;
-  font-size: 1.5rem;
+  font-size: 1.55rem;
   font-style: italic;
-  line-height: 1.55;
+  line-height: 1.6;
   color: var(--slide-muted);
 }
 
@@ -355,6 +426,16 @@ body {
 /* Speaker notes */
 .notes { display: none; }
 
+/* Fragments */
+.fragment {
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.fragment.visible {
+  opacity: 1;
+}
+
 /* Progress bar */
 .progressBarContainer {
   position: fixed;
@@ -444,9 +525,19 @@ body.showDok .dokContainer,
     print-color-adjust: exact !important;
     overflow: visible !important;
     height: auto !important;
+    display: block !important;
   }
 
-  .deck { height: auto !important; overflow: visible !important; }
+  .deck {
+    width: 1920px !important;
+    height: 1080px !important;
+    transform: none !important;
+    box-shadow: none !important;
+    border-radius: 0 !important;
+    overflow: visible !important;
+    margin: 0 !important;
+    position: relative !important;
+  }
 
   .slide {
     position: relative !important;
@@ -463,6 +554,10 @@ body.showDok .dokContainer,
   }
 
   .dokContainer, .progressBarContainer { display: none !important; }
+
+  .fragment {
+    opacity: 1 !important;
+  }
 }
 `;
   }

--- a/packages/core/src/themes/themeEngine.ts
+++ b/packages/core/src/themes/themeEngine.ts
@@ -537,6 +537,10 @@ body.showDok .dokContainer,
     overflow: visible !important;
     margin: 0 !important;
     position: relative !important;
+    left: auto !important;
+    top: auto !important;
+    margin-left: 0 !important;
+    margin-top: 0 !important;
   }
 
   .slide {

--- a/packages/core/src/utils/extractTextLength.ts
+++ b/packages/core/src/utils/extractTextLength.ts
@@ -4,7 +4,15 @@ function extractTextLength(node: SlideNode): number {
   let len = node.value ? node.value.length : 0;
   if (node.children) {
     for (const child of node.children) {
-      len += extractTextLength(child);
+      if (
+        child.type !== 'list' &&
+        child.type !== 'table' &&
+        child.type !== 'code' &&
+        child.type !== 'image' &&
+        child.type !== 'blockquote'
+      ) {
+        len += extractTextLength(child);
+      }
     }
   }
   return len;

--- a/packages/core/tests/normalizer.test.ts
+++ b/packages/core/tests/normalizer.test.ts
@@ -4,6 +4,7 @@ import {
   parseLayoutOveride,
   resolveSlideLayout,
   parseBackgroundImage,
+  parseTitlePositioning,
 } from '../src/normalizer/normalizeLayout.ts';
 import { extractSlideNotes } from '../src/normalizer/normalizeNote.ts';
 import {
@@ -63,6 +64,18 @@ describe('Normalize Layout', () => {
     ];
     const { backgroundImage: bg2 } = parseBackgroundImage(nodesWithUrlWrapper);
     expect(bg2).toBe('https://example.com/bg2.png');
+  });
+
+  test('parseTitlePositioning extracts title alignment and vertical positioning comments', () => {
+    const nodes: RootContent[] = [
+      { type: 'html', value: '<!-- titleAlign: center -->' },
+      { type: 'html', value: '<!-- titlePosition: bottom -->' },
+      { type: 'paragraph', children: [{ type: 'text', value: 'Hello' }] },
+    ];
+    const { titleAlign, titlePosition, filteredNodes } = parseTitlePositioning(nodes);
+    expect(titleAlign).toBe('center');
+    expect(titlePosition).toBe('bottom');
+    expect(filteredNodes).toHaveLength(1);
   });
 
   test('resolveSlideLayout returns custom layout if layoutOverride is valid', () => {

--- a/packages/core/tests/normalizer.test.ts
+++ b/packages/core/tests/normalizer.test.ts
@@ -1,8 +1,16 @@
 import { describe, test, expect } from 'vitest';
 import { normalizeHeading } from '../src/normalizer/normalizeHeading.ts';
-import { parseLayoutOveride, resolveSlideLayout } from '../src/normalizer/normalizeLayout.ts';
+import {
+  parseLayoutOveride,
+  resolveSlideLayout,
+  parseBackgroundImage,
+} from '../src/normalizer/normalizeLayout.ts';
 import { extractSlideNotes } from '../src/normalizer/normalizeNote.ts';
-import { toSlideAstNode, normalizeSlide, normalizeSlides } from '../src/normalizer/mdAstToSlideBasedAst.ts';
+import {
+  toSlideAstNode,
+  normalizeSlide,
+  normalizeSlides,
+} from '../src/normalizer/mdAstToSlideBasedAst.ts';
 import type { Heading, RootContent } from 'mdast';
 import type { RawSlideBlock } from '../src/interfaces/index.ts';
 
@@ -39,6 +47,22 @@ describe('Normalize Layout', () => {
     const { layoutOverride, filteredNodes } = parseLayoutOveride(nodes);
     expect(layoutOverride).toBeUndefined();
     expect(filteredNodes).toHaveLength(2);
+  });
+
+  test('parseBackgroundImage extracts background image comments and cleans wrapper', () => {
+    const nodes: RootContent[] = [
+      { type: 'html', value: '<!-- backgroundImage: https://example.com/bg.png -->' },
+      { type: 'paragraph', children: [{ type: 'text', value: 'Hello' }] },
+    ];
+    const { backgroundImage, filteredNodes } = parseBackgroundImage(nodes);
+    expect(backgroundImage).toBe('https://example.com/bg.png');
+    expect(filteredNodes).toHaveLength(1);
+
+    const nodesWithUrlWrapper: RootContent[] = [
+      { type: 'html', value: '<!-- background-image: url("https://example.com/bg2.png") -->' },
+    ];
+    const { backgroundImage: bg2 } = parseBackgroundImage(nodesWithUrlWrapper);
+    expect(bg2).toBe('https://example.com/bg2.png');
   });
 
   test('resolveSlideLayout returns custom layout if layoutOverride is valid', () => {
@@ -149,13 +173,28 @@ describe('normalizeSlide', () => {
     expect(slide.content[0].type).toBe('paragraph');
     expect(slide.notes).toBe('Speaker note');
   });
+
+  test('normalizes slide block with background image comment', () => {
+    const rawBlock: RawSlideBlock = {
+      id: 'slide-bg',
+      nodes: [
+        { type: 'html', value: '<!-- backgroundImage: https://example.com/bg.png dark -->' },
+        { type: 'heading', depth: 1, children: [{ type: 'text', value: 'Slide Title' }] },
+      ],
+    };
+    const slide = normalizeSlide(rawBlock);
+    expect(slide.backgroundImage).toBe('https://example.com/bg.png dark');
+  });
 });
 
 describe('normalizeSlides', () => {
   test('filters out slides with no title and no content', () => {
     const rawBlocks: RawSlideBlock[] = [
       { id: '1', nodes: [] }, // empty slide
-      { id: '2', nodes: [{ type: 'heading', depth: 2, children: [{ type: 'text', value: 'Title' }] }] },
+      {
+        id: '2',
+        nodes: [{ type: 'heading', depth: 2, children: [{ type: 'text', value: 'Title' }] }],
+      },
     ];
     const slides = normalizeSlides(rawBlocks);
     expect(slides).toHaveLength(1);

--- a/packages/core/tests/normalizer.test.ts
+++ b/packages/core/tests/normalizer.test.ts
@@ -5,6 +5,7 @@ import {
   resolveSlideLayout,
   parseBackgroundImage,
   parseTitlePositioning,
+  parseOverflowConfig,
 } from '../src/normalizer/normalizeLayout.ts';
 import { extractSlideNotes } from '../src/normalizer/normalizeNote.ts';
 import {
@@ -76,6 +77,17 @@ describe('Normalize Layout', () => {
     expect(titleAlign).toBe('center');
     expect(titlePosition).toBe('bottom');
     expect(filteredNodes).toHaveLength(1);
+  });
+
+  test('parseOverflowConfig extracts overflow comments and filters nodes', () => {
+    const nodes: RootContent[] = [
+      { type: 'html', value: '<!-- overflow: split -->' },
+      { type: 'paragraph', children: [{ type: 'text', value: 'Hello' }] },
+    ];
+    const { overflow, filteredNodes } = parseOverflowConfig(nodes);
+    expect(overflow).toBe('split');
+    expect(filteredNodes).toHaveLength(1);
+    expect(filteredNodes[0].type).toBe('paragraph');
   });
 
   test('resolveSlideLayout returns custom layout if layoutOverride is valid', () => {

--- a/packages/core/tests/overflow.test.ts
+++ b/packages/core/tests/overflow.test.ts
@@ -9,7 +9,10 @@ describe('Overflow Engine', () => {
       id: 'slide-1',
       title: 'Short Slide',
       content: [
-        createSlideNode({ type: 'paragraph', children: [createSlideNode({ type: 'text', value: 'Hello' })] }),
+        createSlideNode({
+          type: 'paragraph',
+          children: [createSlideNode({ type: 'text', value: 'Hello' })],
+        }),
       ],
     });
 
@@ -46,12 +49,14 @@ describe('Overflow Engine', () => {
   test('splits long list when height budget is exceeded', () => {
     // List item base height = max(22, wrapLines * 20)
     // 35 items of ~25px each = ~875px, which is > 650px.
-    const listItems = Array(35).fill(null).map((_, i) =>
-      createSlideNode({
-        type: 'listItem',
-        children: [createSlideNode({ type: 'text', value: `List item number ${i}` })],
-      })
-    );
+    const listItems = Array(35)
+      .fill(null)
+      .map((_, i) =>
+        createSlideNode({
+          type: 'listItem',
+          children: [createSlideNode({ type: 'text', value: `List item number ${i}` })],
+        })
+      );
 
     const slide = createSlide({
       id: 'slide-list',
@@ -75,12 +80,19 @@ describe('Overflow Engine', () => {
   test('splits general flat content slide when height budget is exceeded', () => {
     // 30 paragraph nodes. Each paragraph = ~28px.
     // 30 * 28 = 840px > 650px.
-    const paragraphs = Array(30).fill(null).map((_, i) =>
-      createSlideNode({
-        type: 'paragraph',
-        children: [createSlideNode({ type: 'text', value: `This is paragraph number ${i} which has some content text.` })],
-      })
-    );
+    const paragraphs = Array(30)
+      .fill(null)
+      .map((_, i) =>
+        createSlideNode({
+          type: 'paragraph',
+          children: [
+            createSlideNode({
+              type: 'text',
+              value: `This is paragraph number ${i} which has some content text.`,
+            }),
+          ],
+        })
+      );
 
     const slide = createSlide({
       id: 'slide-paragraphs',
@@ -93,5 +105,25 @@ describe('Overflow Engine', () => {
     expect(result[0].id).toBe('slide-paragraphs');
     expect(result[1].id).toBe('slide-paragraphs-cont-p1');
     expect(result[1].title).toBe('Long Paragraphs (Cont.)');
+  });
+
+  test('does not split code block if it is a mermaid diagram', () => {
+    const lines = Array(45).fill('A --> B').join('\n');
+    const slide = createSlide({
+      id: 'slide-mermaid',
+      title: 'Mermaid Diagram',
+      content: [
+        createSlideNode({
+          type: 'code',
+          lang: 'mermaid',
+          value: lines,
+        }),
+      ],
+    });
+
+    const result = processOverflow([slide]);
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toHaveLength(1);
+    expect(result[0].content[0].value).toBe(lines);
   });
 });

--- a/packages/core/tests/overflow.test.ts
+++ b/packages/core/tests/overflow.test.ts
@@ -29,6 +29,7 @@ describe('Overflow Engine', () => {
     const slide = createSlide({
       id: 'slide-code',
       title: 'Long Code Block',
+      overflow: 'split',
       content: [
         createSlideNode({
           type: 'code',
@@ -61,6 +62,7 @@ describe('Overflow Engine', () => {
     const slide = createSlide({
       id: 'slide-list',
       title: 'Long List',
+      overflow: 'split',
       content: [
         createSlideNode({
           type: 'list',
@@ -97,6 +99,7 @@ describe('Overflow Engine', () => {
     const slide = createSlide({
       id: 'slide-paragraphs',
       title: 'Long Paragraphs',
+      overflow: 'split',
       content: paragraphs,
     });
 
@@ -125,5 +128,75 @@ describe('Overflow Engine', () => {
     expect(result).toHaveLength(1);
     expect(result[0].content).toHaveLength(1);
     expect(result[0].content[0].value).toBe(lines);
+  });
+
+  test('does not split long code block by default', () => {
+    const lines = Array(45).fill('console.log("line");').join('\n');
+    const slide = createSlide({
+      id: 'slide-code-default',
+      title: 'Long Code Block Default',
+      content: [
+        createSlideNode({
+          type: 'code',
+          value: lines,
+        }),
+      ],
+    });
+
+    const result = processOverflow([slide]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('slide-code-default');
+  });
+
+  test('does not split long list by default', () => {
+    const listItems = Array(35)
+      .fill(null)
+      .map((_, i) =>
+        createSlideNode({
+          type: 'listItem',
+          children: [createSlideNode({ type: 'text', value: `List item number ${i}` })],
+        })
+      );
+
+    const slide = createSlide({
+      id: 'slide-list-default',
+      title: 'Long List Default',
+      content: [
+        createSlideNode({
+          type: 'list',
+          children: listItems,
+        }),
+      ],
+    });
+
+    const result = processOverflow([slide]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('slide-list-default');
+  });
+
+  test('does not split general flat content slide by default', () => {
+    const paragraphs = Array(30)
+      .fill(null)
+      .map((_, i) =>
+        createSlideNode({
+          type: 'paragraph',
+          children: [
+            createSlideNode({
+              type: 'text',
+              value: `This is paragraph number ${i} which has some content text.`,
+            }),
+          ],
+        })
+      );
+
+    const slide = createSlide({
+      id: 'slide-paragraphs-default',
+      title: 'Long Paragraphs Default',
+      content: paragraphs,
+    });
+
+    const result = processOverflow([slide]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('slide-paragraphs-default');
   });
 });

--- a/packages/core/tests/renderer.test.ts
+++ b/packages/core/tests/renderer.test.ts
@@ -50,7 +50,10 @@ describe('Node and Children Renderer', () => {
     expect(nodeToHtml(bq)).toBe('<blockquote>quote</blockquote>');
 
     const img = createSlideNode({ type: 'image', url: 'foo.png', alt: 'bar' });
-    expect(nodeToHtml(img)).toBe('<img src="foo.png" alt="bar" loading="lazy" />');
+    const imgHtml = nodeToHtml(img);
+    expect(imgHtml).toContain('class="fragment"');
+    expect(imgHtml).toContain('id="frag-');
+    expect(imgHtml).toContain('src="foo.png" alt="bar"');
 
     const link = createSlideNode({
       type: 'link',
@@ -71,7 +74,9 @@ describe('Node and Children Renderer', () => {
         }),
       ],
     });
-    expect(nodeToHtml(ul)).toBe('<ul><li>item</li></ul>');
+    const ulHtml = nodeToHtml(ul);
+    expect(ulHtml).toContain('<li class="fragment" id="frag-');
+    expect(ulHtml).toContain('">item</li>');
 
     const ol = createSlideNode({
       type: 'list',
@@ -83,7 +88,9 @@ describe('Node and Children Renderer', () => {
         }),
       ],
     });
-    expect(nodeToHtml(ol)).toBe('<ol><li>item</li></ol>');
+    const olHtml = nodeToHtml(ol);
+    expect(olHtml).toContain('<li class="fragment" id="frag-');
+    expect(olHtml).toContain('">item</li>');
   });
 
   test('renderCodeBlock generates styled blocks', () => {
@@ -184,7 +191,9 @@ describe('Slide and Deck Renderer', () => {
     expect(html).toContain('<div class="splitLayout">');
     expect(html).toContain('<div class="splitColumn textColumn">');
     expect(html).toContain('<div class="splitColumn imageColumn">');
-    expect(html).toContain('<img src="logo.png" alt="Logo" loading="lazy" />');
+    expect(html).toContain('src="logo.png" alt="Logo"');
+    expect(html).toContain('class="fragment"');
+    expect(html).toContain('id="frag-');
   });
 
   test('renderDeck generates complete template with scripts', () => {
@@ -241,7 +250,10 @@ describe('Slide and Deck Renderer', () => {
         createSlideNode({ type: 'text', value: '   ' }), // whitespace text node
       ],
     });
-    expect(nodeToHtml(node)).toBe('<img src="img.png" alt="" loading="lazy" />');
+    const rendered = nodeToHtml(node);
+    expect(rendered).toContain('src="img.png" alt=""');
+    expect(rendered).toContain('class="fragment"');
+    expect(rendered).toContain('id="frag-');
   });
 
   test('nodeToHtml handles list carrying a nested image', () => {
@@ -267,8 +279,10 @@ describe('Slide and Deck Renderer', () => {
 
     const html = nodeToHtml(listNode);
     expect(html).toContain('<ul>');
-    expect(html).toContain('<li>No image here</li>');
-    expect(html).toContain('<li>With image</li>');
+    expect(html).toContain('class="fragment"');
+    expect(html).toContain('id="frag-');
+    expect(html).toContain('No image here</li>');
+    expect(html).toContain('With image</li>');
     expect(html).toContain('<div class="inlineImageGrid">');
     expect(html).toContain('<img src="nested.png"');
   });

--- a/packages/core/tests/renderer.test.ts
+++ b/packages/core/tests/renderer.test.ts
@@ -1,5 +1,11 @@
 import { describe, test, expect } from 'vitest';
-import { renderDeck, renderSlide, nodeToHtml, childrenToHtml, renderListItemText } from '../src/renderer/html/index.ts';
+import {
+  renderDeck,
+  renderSlide,
+  nodeToHtml,
+  childrenToHtml,
+  renderListItemText,
+} from '../src/renderer/html/index.ts';
 import { renderCodeBlock, renderInlineCode } from '../src/renderer/html/renderCode.ts';
 import { renderTable, renderTableRow, renderTableCell } from '../src/renderer/html/renderTable.ts';
 import { createSlide, createSlideNode } from '../src/ast/createSlideNode.ts';
@@ -7,7 +13,9 @@ import { sanitizeHtml } from '../src/utils/html.ts';
 
 describe('HTML Sanitization', () => {
   test('escapes HTML special characters', () => {
-    expect(sanitizeHtml('<div>Hello & Welcome</div>')).toBe('&lt;div&gt;Hello &amp; Welcome&lt;/div&gt;');
+    expect(sanitizeHtml('<div>Hello & Welcome</div>')).toBe(
+      '&lt;div&gt;Hello &amp; Welcome&lt;/div&gt;'
+    );
   });
 });
 
@@ -80,7 +88,9 @@ describe('Node and Children Renderer', () => {
 
   test('renderCodeBlock generates styled blocks', () => {
     const tsNode = createSlideNode({ type: 'code', lang: 'typescript', value: 'const a = 1;' });
-    expect(renderCodeBlock(tsNode)).toBe('<pre class="lineNumbers language-typescript"><code class="language-typescript">const a = 1;</code></pre>');
+    expect(renderCodeBlock(tsNode)).toBe(
+      '<pre class="lineNumbers language-typescript"><code class="language-typescript">const a = 1;</code></pre>'
+    );
 
     const rawNode = createSlideNode({ type: 'code', value: 'raw code' });
     expect(renderCodeBlock(rawNode)).toBe('<pre><code>raw code</code></pre>');
@@ -90,10 +100,18 @@ describe('Node and Children Renderer', () => {
   });
 
   test('renderTable renders table components', () => {
-    const thNode = createSlideNode({ type: 'tableCell', header: true, children: [createSlideNode({ type: 'text', value: 'head' })] });
+    const thNode = createSlideNode({
+      type: 'tableCell',
+      header: true,
+      children: [createSlideNode({ type: 'text', value: 'head' })],
+    });
     expect(renderTableCell(thNode, childrenToHtml)).toBe('<th>head</th>');
 
-    const tdNode = createSlideNode({ type: 'tableCell', header: false, children: [createSlideNode({ type: 'text', value: 'data' })] });
+    const tdNode = createSlideNode({
+      type: 'tableCell',
+      header: false,
+      children: [createSlideNode({ type: 'text', value: 'data' })],
+    });
     expect(renderTableCell(tdNode, childrenToHtml)).toBe('<td>data</td>');
 
     const trNode = createSlideNode({ type: 'tableRow', children: [tdNode] });
@@ -111,7 +129,10 @@ describe('Slide and Deck Renderer', () => {
       type: 'content',
       title: 'Slide Title',
       content: [
-        createSlideNode({ type: 'paragraph', children: [createSlideNode({ type: 'text', value: 'Body content' })] }),
+        createSlideNode({
+          type: 'paragraph',
+          children: [createSlideNode({ type: 'text', value: 'Body content' })],
+        }),
       ],
       notes: 'Speaker Note',
     });
@@ -129,8 +150,14 @@ describe('Slide and Deck Renderer', () => {
       id: 'slide-split',
       type: 'split',
       content: [
-        createSlideNode({ type: 'column', children: [createSlideNode({ type: 'text', value: 'Left Column' })] }),
-        createSlideNode({ type: 'column', children: [createSlideNode({ type: 'text', value: 'Right Column' })] }),
+        createSlideNode({
+          type: 'column',
+          children: [createSlideNode({ type: 'text', value: 'Left Column' })],
+        }),
+        createSlideNode({
+          type: 'column',
+          children: [createSlideNode({ type: 'text', value: 'Right Column' })],
+        }),
       ],
     });
 
@@ -145,7 +172,10 @@ describe('Slide and Deck Renderer', () => {
       id: 'slide-auto-split',
       type: 'split',
       content: [
-        createSlideNode({ type: 'paragraph', children: [createSlideNode({ type: 'text', value: 'Text explanation' })] }),
+        createSlideNode({
+          type: 'paragraph',
+          children: [createSlideNode({ type: 'text', value: 'Text explanation' })],
+        }),
         createSlideNode({ type: 'image', url: 'logo.png', alt: 'Logo' }),
       ],
     });
@@ -182,10 +212,12 @@ describe('Slide and Deck Renderer', () => {
   test('renderListItemText handles different node types', () => {
     // image node -> ''
     expect(renderListItemText(createSlideNode({ type: 'image', url: 'foo.png' }))).toBe('');
-    
+
     // text node -> escaped value
-    expect(renderListItemText(createSlideNode({ type: 'text', value: 'hello <world>' }))).toBe('hello &lt;world&gt;');
-    
+    expect(renderListItemText(createSlideNode({ type: 'text', value: 'hello <world>' }))).toBe(
+      'hello &lt;world&gt;'
+    );
+
     // children nodes -> join
     const parent = createSlideNode({
       type: 'listItem',
@@ -249,7 +281,11 @@ describe('Slide and Deck Renderer', () => {
         createSlideNode({
           type: 'tableRow',
           children: [
-            createSlideNode({ type: 'tableCell', header: true, children: [createSlideNode({ type: 'text', value: 'H1' })] }),
+            createSlideNode({
+              type: 'tableCell',
+              header: true,
+              children: [createSlideNode({ type: 'text', value: 'H1' })],
+            }),
           ],
         }),
       ],
@@ -288,5 +324,23 @@ describe('Slide and Deck Renderer', () => {
     expect(html).not.toContain('<div class="splitLayout">');
     expect(html).toContain('img1.png');
     expect(html).toContain('img2.png');
+  });
+
+  test('nodeToHtml renders math and inlineMath nodes using KaTeX', () => {
+    const inlineMath = createSlideNode({ type: 'inlineMath' as any, value: 'c^2 = a^2 + b^2' });
+    const htmlInline = nodeToHtml(inlineMath);
+    expect(htmlInline).toContain('class="math math-inline"');
+    expect(htmlInline).toContain('katex');
+
+    const blockMath = createSlideNode({ type: 'math' as any, value: '\\sum_{i=1}^n i' });
+    const htmlBlock = nodeToHtml(blockMath);
+    expect(htmlBlock).toContain('class="math math-display"');
+    expect(htmlBlock).toContain('katex-display');
+  });
+
+  test('nodeToHtml renders mermaid code block as div with class mermaid', () => {
+    const node = createSlideNode({ type: 'code', lang: 'mermaid', value: 'graph TD\nA --> B' });
+    const html = nodeToHtml(node);
+    expect(html).toBe('<div class="mermaid">graph TD\nA --&gt; B</div>');
   });
 });

--- a/packages/core/tests/renderer.test.ts
+++ b/packages/core/tests/renderer.test.ts
@@ -329,12 +329,12 @@ describe('Slide and Deck Renderer', () => {
   test('nodeToHtml renders math and inlineMath nodes using KaTeX', () => {
     const inlineMath = createSlideNode({ type: 'inlineMath' as any, value: 'c^2 = a^2 + b^2' });
     const htmlInline = nodeToHtml(inlineMath);
-    expect(htmlInline).toContain('class="math math-inline"');
+    expect(htmlInline).toContain('class="math mathInline"');
     expect(htmlInline).toContain('katex');
 
     const blockMath = createSlideNode({ type: 'math' as any, value: '\\sum_{i=1}^n i' });
     const htmlBlock = nodeToHtml(blockMath);
-    expect(htmlBlock).toContain('class="math math-display"');
+    expect(htmlBlock).toContain('class="math mathDisplay"');
     expect(htmlBlock).toContain('katex-display');
   });
 

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -1,0 +1,80 @@
+# @mindfiredigital/mdslide-parser
+
+A standalone Markdown parser that compiles markdown strings into standard MDAST (Markdown Abstract Syntax Tree) JSON structures. It does not perform slide-based splitting, acting as a clean, decoupled parsing library.
+
+## Installation
+
+Install as a dependency:
+
+```bash
+npm install @mindfiredigital/mdslide-parser
+# or
+bun add @mindfiredigital/mdslide-parser
+```
+
+---
+
+## 🛠 Programmatic API Usage
+
+The default export function can be imported and called directly.
+
+### 1. Default Parsing
+
+```typescript
+import parser from '@mindfiredigital/mdslide-parser';
+
+const ast = parser('# Hello World\nParagraph content.');
+console.log(JSON.stringify(ast, null, 2));
+```
+
+### 2. Clean AST (Strip Coordinates/Positions)
+
+If you don't need line/column coordinate numbers in your AST, you can strip them:
+
+- **Options parameter**:
+  ```typescript
+  const ast = parser(markdown, { clean: true });
+  ```
+- **Method Chaining**:
+  ```typescript
+  const ast = parser(markdown).clean();
+  ```
+- **Namespace Helper**:
+  ```typescript
+  const ast = parser.clean(markdown);
+  // Strip position from an existing AST object
+  const stripped = parser.strip(originalAst);
+  ```
+- **Builder Pattern**:
+  ```typescript
+  const ast = parser().clean(markdown);
+  const ast2 = parser().parse(markdown, { clean: true });
+  ```
+
+---
+
+## CLI Usage
+
+You can run the standalone parser CLI to dump MDAST JSON files directly from the command line:
+
+```bash
+# Globally installed, or via npx/bunx:
+npx mdslide-parser input.md [options]
+```
+
+### CLI Options:
+
+- `-o, --output <file>`: Specify output JSON file path. Defaults to `<input-file-name>.json`.
+- `-c, --clean`: Strip positions and coordinates from the output AST nodes.
+- `-h, --help`: Show help documentation.
+- `-v, --version`: Show version number.
+
+### Examples:
+
+```bash
+# Parse to input.json (includes coordinates)
+npx mdslide-parser input.md
+
+# Parse to custom output file and strip coordinates
+npx mdslide-parser input.md -o output.json --clean
+```

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.5"
   },

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -1,6 +1,7 @@
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
 import type { Root } from 'mdast';
 
 export type ParsedAST = Root & {
@@ -39,7 +40,7 @@ export function stripPositions(node: any): any {
 }
 
 export function parseMarkdownToAST(markdown: string, options?: { clean?: boolean }): ParsedAST {
-  const root = unified().use(remarkParse).use(remarkGfm).parse(markdown) as Root;
+  const root = unified().use(remarkParse).use(remarkGfm).use(remarkMath).parse(markdown) as Root;
 
   // Define clean method on standard Root
   Object.defineProperty(root, 'clean', {

--- a/packages/parser/tests/parser.test.ts
+++ b/packages/parser/tests/parser.test.ts
@@ -49,6 +49,33 @@ This is a paragraph.
     expect((table as any).children).toHaveLength(2); // header row + body row
   });
 
+  test('parses markdown math features (like inline and block math)', () => {
+    const md = `
+Inline math: $E = mc^2$
+
+Block math:
+$$
+a^2 + b^2 = c^2
+$$
+    `;
+    const ast = parseMarkdownToAST(md);
+
+    let inlineMathNode: any = null;
+    let mathNode: any = null;
+
+    function walk(node: any) {
+      if (node.type === 'inlineMath') inlineMathNode = node;
+      if (node.type === 'math') mathNode = node;
+      if (node.children) node.children.forEach(walk);
+    }
+    ast.children.forEach(walk);
+
+    expect(inlineMathNode).not.toBeNull();
+    expect(inlineMathNode.value).toBe('E = mc^2');
+    expect(mathNode).not.toBeNull();
+    expect(mathNode.value.trim()).toBe('a^2 + b^2 = c^2');
+  });
+
   describe('Clean AST Options and Chaining', () => {
     const md = '# Hello World\nParagraph content.';
 

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,8 @@
+# @mindfiredigital/mdslide-shared
+
+Shared utility types, constants, and helper functions used across `mdslide` monorepo packages.
+
+## 📦 Contents
+
+- **Common TypeScript Types**: Definitions for layout properties, format targets, CLI inputs, and options.
+- **Shared Helpers**: Common validation and string utils.

--- a/packages/shared/src/types/types.ts
+++ b/packages/shared/src/types/types.ts
@@ -31,6 +31,7 @@ export interface Slide {
   backgroundImage?: string;
   titleAlign?: string;
   titlePosition?: string;
+  overflow?: string;
 }
 
 export interface SlideDeck {

--- a/packages/shared/src/types/types.ts
+++ b/packages/shared/src/types/types.ts
@@ -27,6 +27,7 @@ export interface Slide {
   content: SlideNode[];
   notes?: string;
   layoutOverride?: string;
+  backgroundImage?: string;
 }
 
 export interface SlideDeck {

--- a/packages/shared/src/types/types.ts
+++ b/packages/shared/src/types/types.ts
@@ -18,6 +18,7 @@ export interface SlideNode {
   url?: string;
   alt?: string;
   header?: boolean;
+  depth?: number;
 }
 
 export interface Slide {
@@ -28,6 +29,8 @@ export interface Slide {
   notes?: string;
   layoutOverride?: string;
   backgroundImage?: string;
+  titleAlign?: string;
+  titlePosition?: string;
 }
 
 export interface SlideDeck {

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    }
+  }
+}


### PR DESCRIPTION
## **Description**

### Overview
Currently, mdslide automatically splits slides when visual overflow is detected. This PR changes the default behavior to clip overflowing content (overflow: hidden via CSS) without auto-creating continuation slides.

Users can explicitly opt-in to auto-splitting by:

1. Writing <!-- overflow: split --> at the top of a specific slide.
2. Adding overflow: split in the deck-level frontmatter metadata at the top of the Markdown file.
Key Changes

closes #94 