### PR TITLE
Feat/Custom slide headers and typography scaling via frontmatter

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,14 +9,14 @@
 # Reference: https://docs.coderabbit.ai/reference/configuration
 # ---------------------------------------------------------------------------
 
-language: 'en-US'
+language: "en-US"
 
-tone_instructions: 'Senior Node/TypeScript reviewer. Be concise. Prioritise monorepo boundaries, Node/CLI process spawning, browser automation (headless chrome for PDF/PPTX), markdown rendering & AST parsing safety, local HTTP server security, test coverage, and Turborepo setup. Flag real architectural risks; suggest concrete code improvements.'
+tone_instructions: "Senior Node/TS reviewer. Be concise. Prioritise monorepo boundaries, safe CLI process spawning (headless chrome), AST parsing safety, local HTTP security, test coverage, and Turborepo. Flag architectural risks and offer concrete fixes."
 
 early_access: false
 
 reviews:
-  profile: 'assertive'
+  profile: "assertive"
   request_changes_workflow: true
 
   high_level_summary: true
@@ -26,7 +26,6 @@ reviews:
     and Tooling/CI. End with "Breaking changes: None" unless a CLI command,
     output format, or programmatic API changes.
   high_level_summary_in_walkthrough: false
-
   collapse_walkthrough: false
   changed_files_summary: true
   sequence_diagrams: true
@@ -55,16 +54,16 @@ reviews:
       - dev
 
   path_filters:
-    - '!dist/**'
-    - '!coverage/**'
-    - '!node_modules/**'
-    - '!bun.lock'
-    - '!**/*.snap'
-    - '!**/__snapshots__/**'
-    - '!**/*.{png,jpg,jpeg,gif,webp,ico,zip}'
+    - "!dist/**"
+    - "!coverage/**"
+    - "!node_modules/**"
+    - "!bun.lock"
+    - "!**/*.snap"
+    - "!**/__snapshots__/**"
+    - "!**/*.{png,jpg,jpeg,gif,webp,ico,zip}"
 
   path_instructions:
-    - path: 'packages/cli/src/**/*.ts'
+    - path: "packages/cli/src/**/*.ts"
       instructions: |
         Review as CLI utility code.
         - CLI parsing (cac) options must stay clean, robust, and correctly typed.
@@ -72,72 +71,73 @@ reviews:
         - Local preview server (watch command) must secure port bindings, dispose of listeners, and avoid memory leaks.
         - Directory/file creation and path resolution must prevent directory traversal (e.g. resolve output paths safely).
 
-    - path: 'packages/core/src/**/*.ts'
+    - path: "packages/core/src/**/*.ts"
       instructions: |
         Review as core slide compilation code.
         - Base CSS and themeEngine template overrides must be clean and responsive.
         - Math typesetting (KaTeX) rendering must handle rendering errors gracefully without crashing the compiler.
         - HTML sanitization (sanitizeHtml/sanitizeUrl) must block script injection (javascript: URLs, inline event handlers).
 
-    - path: 'packages/parser/src/**/*.ts'
+    - path: "packages/parser/src/**/*.ts"
       instructions: |
         Review as slide Markdown parser code.
         - Markdown AST parsing and node transformations should be deterministic.
         - Handle invalid or malformed slide syntax gracefully, generating helpful warnings/errors instead of throwing.
         - Handle edge cases in layout metadata parsed from markdown.
 
-    - path: 'packages/shared/src/**/*.ts'
+    - path: "packages/shared/src/**/*.ts"
       instructions: |
         Review shared packages definitions and types.
         - Types, interfaces, and contracts must remain robust and backwards-compatible.
         - Check for precise types rather than arbitrary any/object.
 
-    - path: 'packages/cli/tests/**/*.ts'
+    - path: "packages/cli/tests/**/*.ts"
       instructions: |
         Review CLI unit tests (Vitest).
         - Test coverage must verify success and error flows (especially parser, CLI commands, and themes).
         - Spawning/API calls (like Chrome or server listens) should be properly mocked to keep tests fast and platform-independent.
         - Use clean teardown to prevent side effects in the filesystem.
 
-    - path: 'cypress/**/*.ts'
+    - path: "cypress/**/*.ts"
       instructions: |
         Review E2E tests (Cypress).
         - Check slide interaction, page navigation, fullscreen triggers, and rendering assertions.
         - Avoid fragile selectors; prefer test-specific attributes or robust text matchers.
 
-    - path: '.github/workflows/**/*.yml'
+    - path: ".github/workflows/**/*.yml"
       instructions: |
         Review CI/CD.
         - Actions should use version tags, not @main.
         - Secrets must use ${{ secrets.* }} and never be hardcoded.
         - CI should install with pinned Bun, then run lint, typecheck, tests, and build.
 
-    - path: 'tsup.config.*'
+    - path: "tsup.config.*"
       instructions: |
         Review bundle config.
         - Entries must stay separated.
         - Externalize dependencies correctly (Node / internal workspaces packages).
         - Source map settings must be intentional.
 
-    - path: '**/package.json'
+    - path: "**/package.json"
       instructions: |
         Review package-level scripts and dependencies.
         - Ensure correct categorization (dependencies vs devDependencies).
         - Avoid mixing imports across packages without declaring them in package dependencies.
         - Script updates must stay compatible with Bun workspace syntax.
 
-    - path: 'tsconfig*.json'
+    - path: "tsconfig*.json"
       instructions: |
         Review TypeScript configs.
         - Keep strict type safety enabled.
         - Module, target, moduleResolution, paths, and includes must match workspaces boundaries.
 
-    - path: 'eslint.config.*'
+    - path: "eslint.config.*"
       instructions: |
         Review lint config.
         - TS/JS parsing should cover all workspace packages correctly.
         - Avoid disabling rules that hide runtime errors or weaken type safety.
 
+ 
   tools:
     eslint:
       enabled: true
@@ -154,11 +154,11 @@ reviews:
     languagetool:
       enabled: true
       enabled_rules:
-        - 'OXFORD_COMMA'
-        - 'EN_QUOTES'
-        - 'COMMA_PARENTHESIS_WHITESPACE'
+        - "OXFORD_COMMA"
+        - "EN_QUOTES"
+        - "COMMA_PARENTHESIS_WHITESPACE"
       disabled_categories:
-        - 'TYPOGRAPHY'
+        - "TYPOGRAPHY"
     yamllint:
       enabled: true
     ast-grep:
@@ -176,8 +176,8 @@ knowledge_base:
   code_guidelines:
     enabled: true
     filePatterns:
-      - 'README.md'
-      - 'CONTRIBUTING.md'
-      - 'SECURITY.md'
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "SECURITY.md"
   learnings:
     scope: auto

--- a/packages/core/src/ast/createSlideNode.ts
+++ b/packages/core/src/ast/createSlideNode.ts
@@ -28,5 +28,6 @@ export function createSlide(partial: Partial<Slide>): Slide {
     titleAlign: partial.titleAlign,
     titlePosition: partial.titlePosition,
     overflow: partial.overflow,
+    animation: partial.animation,
   };
 }

--- a/packages/core/src/ast/createSlideNode.ts
+++ b/packages/core/src/ast/createSlideNode.ts
@@ -29,5 +29,6 @@ export function createSlide(partial: Partial<Slide>): Slide {
     titlePosition: partial.titlePosition,
     overflow: partial.overflow,
     animation: partial.animation,
+    fontSize: partial.fontSize,
   };
 }

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -48,3 +48,5 @@ export const DEFAULT_TITLE = 'Presentation';
 export const DEFAULT_THEME = 'light';
 
 export const VALID_ANIMATIONS = new Set(['fade', 'slide-up', 'zoom', 'slide-left', 'slide-right']);
+
+export const VALID_FONT_SIZES = new Set(['xs', 'sm', 'md', 'lg', 'xl', 'xxl']);

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -46,3 +46,5 @@ export const SUPPORTED_LANGS = [
 export const DEFAULT_TITLE = 'Presentation';
 
 export const DEFAULT_THEME = 'light';
+
+export const VALID_ANIMATIONS = new Set(['fade', 'slide-up', 'zoom', 'slide-left', 'slide-right']);

--- a/packages/core/src/normalizer/mdAstToSlideBasedAst.ts
+++ b/packages/core/src/normalizer/mdAstToSlideBasedAst.ts
@@ -13,6 +13,8 @@ import {
   parseOverflowConfig,
   parseAnimationConfig,
   normalizeAnimation,
+  parseFontSizeConfig,
+  normalizeFontSize,
 } from './normalizeLayout.js';
 
 // Converts generic MDAST node into Slide AST Node
@@ -72,10 +74,14 @@ export function normalizeSlide(rawBlock: RawSlideBlock): Slide {
     parseAnimationConfig(nodesWithoutOverflow);
   const animation = normalizeAnimation(parsedAnim);
 
+  const { fontSize: parsedFontSize, filteredNodes: nodesWithoutFontSize } =
+    parseFontSizeConfig(nodesWithoutAnim);
+  const fontSize = normalizeFontSize(parsedFontSize);
+
   let slideTitle: string | undefined;
   const slideContent: SlideNode[] = [];
 
-  for (const node of nodesWithoutAnim) {
+  for (const node of nodesWithoutFontSize) {
     if (isHeading(node)) {
       const headingNode = node as Heading;
       const normalized = normalizeHeading(headingNode);
@@ -112,6 +118,7 @@ export function normalizeSlide(rawBlock: RawSlideBlock): Slide {
     titlePosition,
     overflow,
     animation,
+    fontSize,
   });
 }
 
@@ -145,6 +152,10 @@ export function normalizeSlides(
         const animVal = meta.animation ?? meta.build;
         if (animVal && !slide.animation) {
           slide.animation = normalizeAnimation(animVal);
+        }
+        const fontSizeVal = meta.fontSize ?? meta['font-size'] ?? meta.font_size;
+        if (fontSizeVal && !slide.fontSize) {
+          slide.fontSize = normalizeFontSize(fontSizeVal);
         }
       }
       return slide;

--- a/packages/core/src/normalizer/mdAstToSlideBasedAst.ts
+++ b/packages/core/src/normalizer/mdAstToSlideBasedAst.ts
@@ -11,6 +11,8 @@ import {
   parseBackgroundImage,
   parseTitlePositioning,
   parseOverflowConfig,
+  parseAnimationConfig,
+  normalizeAnimation,
 } from './normalizeLayout.js';
 
 // Converts generic MDAST node into Slide AST Node
@@ -66,10 +68,14 @@ export function normalizeSlide(rawBlock: RawSlideBlock): Slide {
 
   const { overflow, filteredNodes: nodesWithoutOverflow } = parseOverflowConfig(nodesWithoutPos);
 
+  const { animation: parsedAnim, filteredNodes: nodesWithoutAnim } =
+    parseAnimationConfig(nodesWithoutOverflow);
+  const animation = normalizeAnimation(parsedAnim);
+
   let slideTitle: string | undefined;
   const slideContent: SlideNode[] = [];
 
-  for (const node of nodesWithoutOverflow) {
+  for (const node of nodesWithoutAnim) {
     if (isHeading(node)) {
       const headingNode = node as Heading;
       const normalized = normalizeHeading(headingNode);
@@ -105,6 +111,7 @@ export function normalizeSlide(rawBlock: RawSlideBlock): Slide {
     titleAlign,
     titlePosition,
     overflow,
+    animation,
   });
 }
 
@@ -134,6 +141,10 @@ export function normalizeSlides(
         const overflow = meta.overflow;
         if (overflow && !slide.overflow) {
           slide.overflow = String(overflow).toLowerCase();
+        }
+        const animVal = meta.animation ?? meta.build;
+        if (animVal && !slide.animation) {
+          slide.animation = normalizeAnimation(animVal);
         }
       }
       return slide;

--- a/packages/core/src/normalizer/normalizeLayout.ts
+++ b/packages/core/src/normalizer/normalizeLayout.ts
@@ -1,5 +1,5 @@
 import { RootContent } from 'mdast';
-import { VALID_SLIDE_TYPES } from '../constants/index.js';
+import { VALID_ANIMATIONS, VALID_SLIDE_TYPES } from '../constants/index.js';
 import { SlideNode, SlideType } from '@mindfiredigital/mdslide-shared';
 
 // Detects manual layout override comments e.g., <!-- layout: dark --> and clear out
@@ -115,6 +115,42 @@ export function parseOverflowConfig(nodes: RootContent[]): {
   }
   return {
     overflow,
+    filteredNodes,
+  };
+}
+
+export function normalizeAnimation(val: unknown): string | undefined {
+  if (!val) return undefined;
+  const str = String(val).toLowerCase().trim();
+  if (str === 'true') {
+    return 'fade';
+  }
+  if (VALID_ANIMATIONS.has(str)) {
+    return str;
+  }
+  return undefined;
+}
+
+export function parseAnimationConfig(nodes: RootContent[]): {
+  animation: string | undefined;
+  filteredNodes: RootContent[];
+} {
+  let animation: string | undefined;
+  const filteredNodes: RootContent[] = [];
+
+  for (const node of nodes) {
+    if (node.type === 'html') {
+      const val = node.value.trim();
+      const animMatch = val.match(/^<!--\s*(animation|build):\s*([\w-]+)\s*-->$/i);
+      if (animMatch) {
+        animation = normalizeAnimation(animMatch[2]);
+        continue;
+      }
+    }
+    filteredNodes.push(node);
+  }
+  return {
+    animation,
     filteredNodes,
   };
 }

--- a/packages/core/src/normalizer/normalizeLayout.ts
+++ b/packages/core/src/normalizer/normalizeLayout.ts
@@ -1,5 +1,5 @@
 import { RootContent } from 'mdast';
-import { VALID_ANIMATIONS, VALID_SLIDE_TYPES } from '../constants/index.js';
+import { VALID_ANIMATIONS, VALID_FONT_SIZES, VALID_SLIDE_TYPES } from '../constants/index.js';
 import { SlideNode, SlideType } from '@mindfiredigital/mdslide-shared';
 
 // Detects manual layout override comments e.g., <!-- layout: dark --> and clear out
@@ -151,6 +151,54 @@ export function parseAnimationConfig(nodes: RootContent[]): {
   }
   return {
     animation,
+    filteredNodes,
+  };
+}
+
+export function normalizeFontSize(val: unknown): string | undefined {
+  if (!val) return undefined;
+  const str = String(val)
+    .toLowerCase()
+    .trim()
+    .replace(/[-\s_]+/g, '-');
+  if (str === 'medium' || str === 'normal') {
+    return 'md';
+  }
+  if (str === 'extra-large') {
+    return 'xl';
+  }
+  if (str === 'extra-small') {
+    return 'xs';
+  }
+  if (str === 'double-extra-large') {
+    return 'xxl';
+  }
+  if (VALID_FONT_SIZES.has(str)) {
+    return str;
+  }
+  return undefined;
+}
+
+export function parseFontSizeConfig(nodes: RootContent[]): {
+  fontSize: string | undefined;
+  filteredNodes: RootContent[];
+} {
+  let fontSize: string | undefined;
+  const filteredNodes: RootContent[] = [];
+
+  for (const node of nodes) {
+    if (node.type === 'html') {
+      const val = node.value.trim();
+      const match = val.match(/^<!--\s*(fontSize):\s*([\w\s-]+)\s*-->$/i);
+      if (match) {
+        fontSize = normalizeFontSize(match[2]);
+        continue;
+      }
+    }
+    filteredNodes.push(node);
+  }
+  return {
+    fontSize,
     filteredNodes,
   };
 }

--- a/packages/core/src/renderer/html/renderSlide.ts
+++ b/packages/core/src/renderer/html/renderSlide.ts
@@ -74,11 +74,11 @@ export function renderListItemText(node: SlideNode): string {
 }
 
 // node to html
-export function childrenToHtml(node: SlideNode): string {
-  return (node.children ?? []).map(nodeToHtml).join('');
+export function childrenToHtml(node: SlideNode, animation?: string): string {
+  return (node.children ?? []).map((c) => nodeToHtml(c, animation)).join('');
 }
 
-export function nodeToHtml(node: SlideNode): string {
+export function nodeToHtml(node: SlideNode, animation?: string): string {
   switch (node.type) {
     case 'paragraph': {
       // Paragraph that is purely image(s)   render as figure, not <p>
@@ -89,25 +89,25 @@ export function nodeToHtml(node: SlideNode): string {
       if (onlyImages) {
         return (node.children ?? [])
           .filter((c) => c.type === 'image')
-          .map((img) => nodeToHtml(img))
+          .map((img) => nodeToHtml(img, animation))
           .join('');
       }
-      return `<p>${childrenToHtml(node)}</p>`;
+      return `<p>${childrenToHtml(node, animation)}</p>`;
     }
 
     case 'heading': {
       const depth = node.depth ?? 3;
-      return `<h${depth}>${childrenToHtml(node)}</h${depth}>`;
+      return `<h${depth}>${childrenToHtml(node, animation)}</h${depth}>`;
     }
 
     case 'text':
       return sanitizeHtml(node.value ?? '');
 
     case 'strong':
-      return `<strong>${childrenToHtml(node)}</strong>`;
+      return `<strong>${childrenToHtml(node, animation)}</strong>`;
 
     case 'emphasis':
-      return `<em>${childrenToHtml(node)}</em>`;
+      return `<em>${childrenToHtml(node, animation)}</em>`;
 
     case 'inlineCode':
       return renderInlineCode(node);
@@ -123,7 +123,7 @@ export function nodeToHtml(node: SlideNode): string {
       const hasNestedImages = (node.children ?? []).some(listItemHasImage);
 
       if (!hasNestedImages) {
-        return `<${tag}>${childrenToHtml(node)}</${tag}>`;
+        return `<${tag}>${childrenToHtml(node, animation)}</${tag}>`;
       }
 
       // Render list items text-only, collect images
@@ -131,55 +131,67 @@ export function nodeToHtml(node: SlideNode): string {
       const itemsHtml = (node.children ?? [])
         .map((item) => {
           if (!listItemHasImage(item)) {
-            globalFragmentCounter++;
-            return `<li class="fragment" id="frag-${globalFragmentCounter}">${childrenToHtml(item)}</li>`;
+            if (animation) {
+              globalFragmentCounter++;
+              return `<li class="fragment" data-animation="${animation}" id="frag-${globalFragmentCounter}">${childrenToHtml(item, animation)}</li>`;
+            }
+            return `<li>${childrenToHtml(item, animation)}</li>`;
           }
           // Extract images from this item
           const { clean, images } = extractImages(item.children ?? []);
           collectedImages.push(...images);
-          const textContent = clean.map(nodeToHtml).join('');
-          globalFragmentCounter++;
-          return `<li class="fragment" id="frag-${globalFragmentCounter}">${textContent}</li>`;
+          const textContent = clean.map((c) => nodeToHtml(c, animation)).join('');
+          if (animation) {
+            globalFragmentCounter++;
+            return `<li class="fragment" data-animation="${animation}" id="frag-${globalFragmentCounter}">${textContent}</li>`;
+          }
+          return `<li>${textContent}</li>`;
         })
         .join('');
 
       // Render collected images in a grid below the list
       const imagesHtml =
         collectedImages.length > 0
-          ? `<div class="inlineImageGrid">${collectedImages.map(nodeToHtml).join('')}</div>`
+          ? `<div class="inlineImageGrid">${collectedImages.map((c) => nodeToHtml(c, animation)).join('')}</div>`
           : '';
 
       return `<${tag}>${itemsHtml}</${tag}>${imagesHtml}`;
     }
 
     case 'listItem': {
-      globalFragmentCounter++;
-      return `<li class="fragment" id="frag-${globalFragmentCounter}">${childrenToHtml(node)}</li>`;
+      if (animation) {
+        globalFragmentCounter++;
+        return `<li class="fragment" data-animation="${animation}" id="frag-${globalFragmentCounter}">${childrenToHtml(node, animation)}</li>`;
+      }
+      return `<li>${childrenToHtml(node, animation)}</li>`;
     }
 
     case 'blockquote':
-      return `<blockquote>${childrenToHtml(node)}</blockquote>`;
+      return `<blockquote>${childrenToHtml(node, animation)}</blockquote>`;
 
     case 'image': {
       const src = node.url ?? node.value ?? '';
       const alt = node.alt ?? '';
-      globalFragmentCounter++;
-      return `<img src="${sanitizeUrl(src, true)}" alt="${sanitizeHtml(alt)}" class="fragment" id="frag-${globalFragmentCounter}" loading="lazy" />`;
+      if (animation) {
+        globalFragmentCounter++;
+        return `<img src="${sanitizeUrl(src, true)}" alt="${sanitizeHtml(alt)}" class="fragment" data-animation="${animation}" id="frag-${globalFragmentCounter}" loading="lazy" />`;
+      }
+      return `<img src="${sanitizeUrl(src, true)}" alt="${sanitizeHtml(alt)}" loading="lazy" />`;
     }
 
     case 'link': {
       const href = node.url ?? node.value ?? '';
-      return `<a href="${sanitizeUrl(href, false)}">${childrenToHtml(node)}</a>`;
+      return `<a href="${sanitizeUrl(href, false)}">${childrenToHtml(node, animation)}</a>`;
     }
 
     case 'table':
-      return renderTable(node, childrenToHtml);
+      return renderTable(node, (n) => childrenToHtml(n, animation));
 
     case 'tableRow':
-      return renderTableRow(node, childrenToHtml);
+      return renderTableRow(node, (n) => childrenToHtml(n, animation));
 
     case 'tableCell':
-      return renderTableCell(node, childrenToHtml);
+      return renderTableCell(node, (n) => childrenToHtml(n, animation));
 
     case 'break':
       return '<br />';
@@ -195,11 +207,11 @@ export function nodeToHtml(node: SlideNode): string {
       return `<span class="math mathInline">${renderMath(node.value ?? '', false)}</span>`;
 
     case 'column':
-      return childrenToHtml(node);
+      return childrenToHtml(node, animation);
 
     default:
       if (node.value) return sanitizeHtml(node.value);
-      if (node.children?.length) return childrenToHtml(node);
+      if (node.children?.length) return childrenToHtml(node, animation);
       return '';
   }
 }
@@ -261,8 +273,8 @@ export function renderSlide(slide: Slide): string {
       // Manual ::split::
       contentHtml = `
         <div class="splitLayout">
-          <div class="splitColumn textColumn">${nodeToHtml(slide.content[0]!)}</div>
-          <div class="splitColumn rightColumn">${nodeToHtml(slide.content[1]!)}</div>
+          <div class="splitColumn textColumn">${nodeToHtml(slide.content[0]!, slide.animation)}</div>
+          <div class="splitColumn rightColumn">${nodeToHtml(slide.content[1]!, slide.animation)}</div>
         </div>`;
     } else {
       // Auto-split: only do text+image split when there is EXACTLY one image
@@ -272,16 +284,16 @@ export function renderSlide(slide: Slide): string {
         const textNodes = removeImageNode(slide.content);
         contentHtml = `
           <div class="splitLayout">
-            <div class="splitColumn textColumn">${textNodes.map(nodeToHtml).join('\n')}</div>
-            <div class="splitColumn imageColumn">${nodeToHtml(imageNode!)}</div>
+            <div class="splitColumn textColumn">${textNodes.map((n) => nodeToHtml(n, slide.animation)).join('\n')}</div>
+            <div class="splitColumn imageColumn">${nodeToHtml(imageNode!, slide.animation)}</div>
           </div>`;
       } else {
         // 0 or 2+ images   render normally, let the list handler show images in a grid
-        contentHtml = slide.content.map(nodeToHtml).join('\n');
+        contentHtml = slide.content.map((n) => nodeToHtml(n, slide.animation)).join('\n');
       }
     }
   } else {
-    contentHtml = slide.content.map(nodeToHtml).join('\n');
+    contentHtml = slide.content.map((n) => nodeToHtml(n, slide.animation)).join('\n');
   }
 
   let bgAttr = '';
@@ -300,8 +312,12 @@ export function renderSlide(slide: Slide): string {
   if (slide.titlePosition) {
     posAttr = ` data-title-position="${sanitizeHtml(slide.titlePosition)}"`;
   }
+  let animAttr = '';
+  if (slide.animation) {
+    animAttr = ` data-animation="${sanitizeHtml(slide.animation)}"`;
+  }
 
-  return `<section class="slide"${bgAttr}${bgStyle}${alignAttr}${posAttr} data-type="${slide.type}" data-id="${slide.id}">
+  return `<section class="slide"${bgAttr}${bgStyle}${alignAttr}${posAttr}${animAttr} data-type="${slide.type}" data-id="${slide.id}">
   ${titleHtml}
   <div class="slideContent">
     ${contentHtml}

--- a/packages/core/src/renderer/html/renderSlide.ts
+++ b/packages/core/src/renderer/html/renderSlide.ts
@@ -316,8 +316,12 @@ export function renderSlide(slide: Slide): string {
   if (slide.animation) {
     animAttr = ` data-animation="${sanitizeHtml(slide.animation)}"`;
   }
+  let fontSizeAttr = '';
+  if (slide.fontSize) {
+    fontSizeAttr = ` data-font-size="${sanitizeHtml(slide.fontSize)}"`;
+  }
 
-  return `<section class="slide"${bgAttr}${bgStyle}${alignAttr}${posAttr}${animAttr} data-type="${slide.type}" data-id="${slide.id}">
+  return `<section class="slide"${bgAttr}${bgStyle}${alignAttr}${posAttr}${animAttr}${fontSizeAttr} data-type="${slide.type}" data-id="${slide.id}">
   ${titleHtml}
   <div class="slideContent">
     ${contentHtml}

--- a/packages/core/src/themes/themeEngine.ts
+++ b/packages/core/src/themes/themeEngine.ts
@@ -468,6 +468,52 @@ body .slide[data-title-position="middle"] .slideContent {
   transform: translateX(0);
 }
 
+/* Font size controls */
+.slide[data-font-size="xs"] {
+  --title-size: 2.04rem;
+  --h2-size: 1.82rem;
+  --h3-size: 1.26rem;
+  --body-size: 0.95rem;
+  --li-size: 0.91rem;
+  --code-size: 0.74rem;
+}
+
+.slide[data-font-size="sm"] {
+  --title-size: 2.72rem;
+  --h2-size: 2.21rem;
+  --h3-size: 1.53rem;
+  --body-size: 1.15rem;
+  --li-size: 1.11rem;
+  --code-size: 0.89rem;
+}
+
+.slide[data-font-size="lg"] {
+  --title-size: 4.25rem;
+  --h2-size: 3.00rem;
+  --h3-size: 2.10rem;
+  --body-size: 1.55rem;
+  --li-size: 1.50rem;
+  --code-size: 1.20rem;
+}
+
+.slide[data-font-size="xl"] {
+  --title-size: 5.10rem;
+  --h2-size: 3.25rem;
+  --h3-size: 2.25rem;
+  --body-size: 1.69rem;
+  --li-size: 1.63rem;
+  --code-size: 1.31rem;
+}
+
+.slide[data-font-size="xxl"] {
+  --title-size: 6.12rem;
+  --h2-size: 3.51rem;
+  --h3-size: 2.43rem;
+  --body-size: 1.82rem;
+  --li-size: 1.76rem;
+  --code-size: 1.42rem;
+}
+
 /* Progress bar */
 .progressBarContainer {
   position: fixed;

--- a/packages/core/src/themes/themeEngine.ts
+++ b/packages/core/src/themes/themeEngine.ts
@@ -429,11 +429,43 @@ body .slide[data-title-position="middle"] .slideContent {
 /* Fragments */
 .fragment {
   opacity: 0;
-  transition: opacity 0.3s ease;
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
 .fragment.visible {
   opacity: 1;
+}
+
+/* Slide Up */
+.fragment[data-animation="slide-up"] {
+  transform: translateY(20px);
+}
+.fragment[data-animation="slide-up"].visible {
+  transform: translateY(0);
+}
+
+/* Zoom */
+.fragment[data-animation="zoom"] {
+  transform: scale(0.92);
+}
+.fragment[data-animation="zoom"].visible {
+  transform: scale(1);
+}
+
+/* Slide Left */
+.fragment[data-animation="slide-left"] {
+  transform: translateX(-20px);
+}
+.fragment[data-animation="slide-left"].visible {
+  transform: translateX(0);
+}
+
+/* Slide Right */
+.fragment[data-animation="slide-right"] {
+  transform: translateX(20px);
+}
+.fragment[data-animation="slide-right"].visible {
+  transform: translateX(0);
 }
 
 /* Progress bar */

--- a/packages/core/tests/normalizer.test.ts
+++ b/packages/core/tests/normalizer.test.ts
@@ -8,6 +8,8 @@ import {
   parseOverflowConfig,
   parseAnimationConfig,
   normalizeAnimation,
+  parseFontSizeConfig,
+  normalizeFontSize,
 } from '../src/normalizer/normalizeLayout.ts';
 import { extractSlideNotes } from '../src/normalizer/normalizeNote.ts';
 import {
@@ -128,6 +130,27 @@ describe('Normalize Layout', () => {
     expect(normalizeAnimation('slide-right')).toBe('slide-right');
     expect(normalizeAnimation('invalid')).toBeUndefined();
     expect(normalizeAnimation(undefined)).toBeUndefined();
+  });
+
+  test('parseFontSizeConfig extracts font size comments and filters nodes', () => {
+    const nodes: RootContent[] = [
+      { type: 'html', value: '<!-- fontSize: sm -->' },
+      { type: 'paragraph', children: [{ type: 'text', value: 'Hello' }] },
+    ];
+    const { fontSize, filteredNodes } = parseFontSizeConfig(nodes);
+    expect(fontSize).toBe('sm');
+    expect(filteredNodes).toHaveLength(1);
+    expect(filteredNodes[0].type).toBe('paragraph');
+  });
+
+  test('normalizeFontSize maps values to standard size strings', () => {
+    expect(normalizeFontSize('xs')).toBe('xs');
+    expect(normalizeFontSize('extra-large')).toBe('xl');
+    expect(normalizeFontSize('extra large')).toBe('xl');
+    expect(normalizeFontSize('xxl')).toBe('xxl');
+    expect(normalizeFontSize('medium')).toBe('md');
+    expect(normalizeFontSize('normal')).toBe('md');
+    expect(normalizeFontSize('invalid')).toBeUndefined();
   });
 
   test('resolveSlideLayout returns custom layout if layoutOverride is valid', () => {

--- a/packages/core/tests/normalizer.test.ts
+++ b/packages/core/tests/normalizer.test.ts
@@ -6,6 +6,8 @@ import {
   parseBackgroundImage,
   parseTitlePositioning,
   parseOverflowConfig,
+  parseAnimationConfig,
+  normalizeAnimation,
 } from '../src/normalizer/normalizeLayout.ts';
 import { extractSlideNotes } from '../src/normalizer/normalizeNote.ts';
 import {
@@ -88,6 +90,44 @@ describe('Normalize Layout', () => {
     expect(overflow).toBe('split');
     expect(filteredNodes).toHaveLength(1);
     expect(filteredNodes[0].type).toBe('paragraph');
+  });
+
+  test('parseAnimationConfig extracts animation comments and filters nodes', () => {
+    const nodes1: RootContent[] = [
+      { type: 'html', value: '<!-- animation: fade -->' },
+      { type: 'paragraph', children: [{ type: 'text', value: 'Hello' }] },
+    ];
+    const { animation: anim1, filteredNodes: filtered1 } = parseAnimationConfig(nodes1);
+    expect(anim1).toBe('fade');
+    expect(filtered1).toHaveLength(1);
+
+    const nodes2: RootContent[] = [
+      { type: 'html', value: '<!-- build: fade -->' },
+      { type: 'paragraph', children: [{ type: 'text', value: 'Hello' }] },
+    ];
+    const { animation: anim2, filteredNodes: filtered2 } = parseAnimationConfig(nodes2);
+    expect(anim2).toBe('fade');
+    expect(filtered2).toHaveLength(1);
+
+    const nodes3: RootContent[] = [
+      { type: 'html', value: '<!-- animation: slide-up -->' },
+      { type: 'paragraph', children: [{ type: 'text', value: 'Hello' }] },
+    ];
+    const { animation: anim3, filteredNodes: filtered3 } = parseAnimationConfig(nodes3);
+    expect(anim3).toBe('slide-up');
+    expect(filtered3).toHaveLength(1);
+  });
+
+  test('normalizeAnimation maps values to standard animation strings', () => {
+    expect(normalizeAnimation('fade')).toBe('fade');
+    expect(normalizeAnimation('true')).toBe('fade');
+    expect(normalizeAnimation('FADE')).toBe('fade');
+    expect(normalizeAnimation('slide-up')).toBe('slide-up');
+    expect(normalizeAnimation('zoom')).toBe('zoom');
+    expect(normalizeAnimation('slide-left')).toBe('slide-left');
+    expect(normalizeAnimation('slide-right')).toBe('slide-right');
+    expect(normalizeAnimation('invalid')).toBeUndefined();
+    expect(normalizeAnimation(undefined)).toBeUndefined();
   });
 
   test('resolveSlideLayout returns custom layout if layoutOverride is valid', () => {

--- a/packages/core/tests/renderer.test.ts
+++ b/packages/core/tests/renderer.test.ts
@@ -406,4 +406,17 @@ describe('Slide and Deck Renderer', () => {
     expect(slideRightHtml).toContain('class="fragment"');
     expect(slideRightHtml).toContain('data-animation="slide-right"');
   });
+
+  test('renderSlide supports custom fontSize attributes', () => {
+    const slide = createSlide({
+      id: 'slide-font-size',
+      type: 'content',
+      fontSize: 'sm',
+      content: [
+        createSlideNode({ type: 'paragraph', children: [{ type: 'text', value: 'Hello sm' }] }),
+      ],
+    });
+    const html = renderSlide(slide);
+    expect(html).toContain('data-font-size="sm"');
+  });
 });

--- a/packages/core/tests/renderer.test.ts
+++ b/packages/core/tests/renderer.test.ts
@@ -51,9 +51,15 @@ describe('Node and Children Renderer', () => {
 
     const img = createSlideNode({ type: 'image', url: 'foo.png', alt: 'bar' });
     const imgHtml = nodeToHtml(img);
-    expect(imgHtml).toContain('class="fragment"');
-    expect(imgHtml).toContain('id="frag-');
+    expect(imgHtml).not.toContain('class="fragment"');
+    expect(imgHtml).not.toContain('id="frag-');
     expect(imgHtml).toContain('src="foo.png" alt="bar"');
+
+    const imgAnimHtml = nodeToHtml(img, 'fade');
+    expect(imgAnimHtml).toContain('class="fragment"');
+    expect(imgAnimHtml).toContain('data-animation="fade"');
+    expect(imgAnimHtml).toContain('id="frag-');
+    expect(imgAnimHtml).toContain('src="foo.png" alt="bar"');
 
     const link = createSlideNode({
       type: 'link',
@@ -75,8 +81,12 @@ describe('Node and Children Renderer', () => {
       ],
     });
     const ulHtml = nodeToHtml(ul);
-    expect(ulHtml).toContain('<li class="fragment" id="frag-');
-    expect(ulHtml).toContain('">item</li>');
+    expect(ulHtml).not.toContain('<li class="fragment"');
+    expect(ulHtml).toContain('<li>item</li>');
+
+    const ulAnimHtml = nodeToHtml(ul, 'fade');
+    expect(ulAnimHtml).toContain('<li class="fragment" data-animation="fade" id="frag-');
+    expect(ulAnimHtml).toContain('">item</li>');
 
     const ol = createSlideNode({
       type: 'list',
@@ -89,8 +99,12 @@ describe('Node and Children Renderer', () => {
       ],
     });
     const olHtml = nodeToHtml(ol);
-    expect(olHtml).toContain('<li class="fragment" id="frag-');
-    expect(olHtml).toContain('">item</li>');
+    expect(olHtml).not.toContain('<li class="fragment"');
+    expect(olHtml).toContain('<li>item</li>');
+
+    const olAnimHtml = nodeToHtml(ol, 'fade');
+    expect(olAnimHtml).toContain('<li class="fragment" data-animation="fade" id="frag-');
+    expect(olAnimHtml).toContain('">item</li>');
   });
 
   test('renderCodeBlock generates styled blocks', () => {
@@ -192,8 +206,12 @@ describe('Slide and Deck Renderer', () => {
     expect(html).toContain('<div class="splitColumn textColumn">');
     expect(html).toContain('<div class="splitColumn imageColumn">');
     expect(html).toContain('src="logo.png" alt="Logo"');
-    expect(html).toContain('class="fragment"');
-    expect(html).toContain('id="frag-');
+    expect(html).not.toContain('class="fragment"');
+
+    const htmlAnim = renderSlide({ ...slide, animation: 'fade' });
+    expect(htmlAnim).toContain('class="fragment"');
+    expect(htmlAnim).toContain('data-animation="fade"');
+    expect(htmlAnim).toContain('id="frag-');
   });
 
   test('renderDeck generates complete template with scripts', () => {
@@ -252,8 +270,12 @@ describe('Slide and Deck Renderer', () => {
     });
     const rendered = nodeToHtml(node);
     expect(rendered).toContain('src="img.png" alt=""');
-    expect(rendered).toContain('class="fragment"');
-    expect(rendered).toContain('id="frag-');
+    expect(rendered).not.toContain('class="fragment"');
+
+    const renderedAnim = nodeToHtml(node, 'fade');
+    expect(renderedAnim).toContain('src="img.png" alt=""');
+    expect(renderedAnim).toContain('class="fragment"');
+    expect(renderedAnim).toContain('data-animation="fade"');
   });
 
   test('nodeToHtml handles list carrying a nested image', () => {
@@ -279,12 +301,19 @@ describe('Slide and Deck Renderer', () => {
 
     const html = nodeToHtml(listNode);
     expect(html).toContain('<ul>');
-    expect(html).toContain('class="fragment"');
-    expect(html).toContain('id="frag-');
+    expect(html).not.toContain('class="fragment"');
     expect(html).toContain('No image here</li>');
     expect(html).toContain('With image</li>');
     expect(html).toContain('<div class="inlineImageGrid">');
     expect(html).toContain('<img src="nested.png"');
+    expect(html).not.toContain('class="fragment"');
+
+    const htmlAnim = nodeToHtml(listNode, 'fade');
+    expect(htmlAnim).toContain('class="fragment" data-animation="fade"');
+    expect(htmlAnim).toContain('No image here</li>');
+    expect(htmlAnim).toContain('With image</li>');
+    expect(htmlAnim).toContain('<div class="inlineImageGrid">');
+    expect(htmlAnim).toContain('<img src="nested.png"');
   });
 
   test('nodeToHtml handles table, html and unknown nodes', () => {
@@ -356,5 +385,25 @@ describe('Slide and Deck Renderer', () => {
     const node = createSlideNode({ type: 'code', lang: 'mermaid', value: 'graph TD\nA --> B' });
     const html = nodeToHtml(node);
     expect(html).toBe('<div class="mermaid">graph TD\nA --&gt; B</div>');
+  });
+
+  test('nodeToHtml supports new animation types', () => {
+    const img = createSlideNode({ type: 'image', url: 'foo.png', alt: 'bar' });
+
+    const slideUpHtml = nodeToHtml(img, 'slide-up');
+    expect(slideUpHtml).toContain('class="fragment"');
+    expect(slideUpHtml).toContain('data-animation="slide-up"');
+
+    const zoomHtml = nodeToHtml(img, 'zoom');
+    expect(zoomHtml).toContain('class="fragment"');
+    expect(zoomHtml).toContain('data-animation="zoom"');
+
+    const slideLeftHtml = nodeToHtml(img, 'slide-left');
+    expect(slideLeftHtml).toContain('class="fragment"');
+    expect(slideLeftHtml).toContain('data-animation="slide-left"');
+
+    const slideRightHtml = nodeToHtml(img, 'slide-right');
+    expect(slideRightHtml).toContain('class="fragment"');
+    expect(slideRightHtml).toContain('data-animation="slide-right"');
   });
 });

--- a/packages/shared/src/types/types.ts
+++ b/packages/shared/src/types/types.ts
@@ -32,6 +32,7 @@ export interface Slide {
   titleAlign?: string;
   titlePosition?: string;
   overflow?: string;
+  animation?: string;
 }
 
 export interface SlideDeck {

--- a/packages/shared/src/types/types.ts
+++ b/packages/shared/src/types/types.ts
@@ -33,6 +33,7 @@ export interface Slide {
   titlePosition?: string;
   overflow?: string;
   animation?: string;
+  fontSize?: string;
 }
 
 export interface SlideDeck {


### PR DESCRIPTION
## Description
This PR introduces customizable slide layouts and responsive typography scaling. Previously, slide dimensions and font sizes were locked to a fixed size.

With this update, users can control slide scaling globally via the main frontmatter or override it locally on individual slides. Instead of just resizing headers, selecting a size dynamically recalculates the font sizes of all nodes (body text, lists, code blocks, etc.) within that slide to maintain perfect visual proportions.

##  Available Sizes
Users can choose from the following pre-configured scale tokens:
- **xs** (Extra Small)
- **sm** (Small)
- **md** (Medium - Default)
- **lg** (Large)
- **xl** (Extra Large)
- **xxl** (Double Extra Large)

# usage

## Global Configuration
```markdown
---
theme: default
fontSize: xxl
---
```

## slide based Configuration

```markdown
<!-- fontSize: xxl -->

# Premium Split Columns
### Auto-Detecting Split Layouts
* **Side-by-Side Design:** When a slide contains exactly one image alongside text content, MdSlide automatically transforms the layout into a gorgeous split column display.
* **Perfect Balance:** 50% left text column, 50% right image column.
* **Visual Polish:** Images feature subtle border radii and drop shadows matching the active theme perfectly.
```