### PR TITLE
Harden release pipeline with concurrency controls, manual dispatch, and fix publish helper backup fidelity

### DIFF
--- a/.changeset/brave-brooms-smell.md
+++ b/.changeset/brave-brooms-smell.md
@@ -1,0 +1,7 @@
+---
+'@mindfiredigital/mdslide-core': patch
+'@mindfiredigital/mdslide-parser': patch
+'@mindfiredigital/mdslide-shared': patch
+---
+
+Test pipeline and version bump

--- a/.changeset/tender-brooms-notice.md
+++ b/.changeset/tender-brooms-notice.md
@@ -1,0 +1,5 @@
+---
+'@mindfiredigital/mdslide-cli': patch
+---
+
+Test changset workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write

--- a/scripts/publishHelper.ts
+++ b/scripts/publishHelper.ts
@@ -14,7 +14,8 @@ function getPackagesInfo() {
   return PACKAGE_NAMES.map((dirName) => {
     const pkgPath = join(PACKAGES_DIR, dirName, 'package.json');
     const backupPath = join(PACKAGES_DIR, dirName, 'package.json.bak');
-    const content = JSON.parse(readFileSync(pkgPath, 'utf8'));
+    const rawContent = readFileSync(pkgPath, 'utf8');
+    const content = JSON.parse(rawContent);
     return {
       dirName,
       pkgPath,
@@ -22,6 +23,7 @@ function getPackagesInfo() {
       name: content.name,
       version: content.version,
       content,
+      rawContent,
     };
   });
 }
@@ -38,7 +40,7 @@ if (command === '--prepare') {
   }
 
   for (const pkg of packagesInfo) {
-    writeFileSync(pkg.backupPath, JSON.stringify(pkg.content, null, 2), 'utf8');
+    writeFileSync(pkg.backupPath, pkg.rawContent, 'utf8');
 
     const updatedContent = JSON.parse(JSON.stringify(pkg.content));
 


### PR DESCRIPTION
### What does this PR do?

This PR improves the reliability and operability of the release pipeline through three targeted changes:

1. **Release workflow enhancements** — Adds `workflow_dispatch` support so the release pipeline can be triggered manually from the GitHub UI (useful for re-runs and testing without pushing commits). Adds a `concurrency` block with `cancel-in-progress: false` to prevent parallel release runs from stomping each other — queuing instead of cancelling ensures no half-published packages.

2. **Publish helper bug fix** — Fixes a subtle bug in `publishHelper.ts` where the `--prepare` step was creating backups by re-serializing `package.json` through `JSON.stringify` instead of preserving the original file content. This could silently alter formatting (trailing newlines, whitespace) and leave a dirty git tree after a `--prepare` → `--restore` cycle. The fix stores the raw file content and writes it back verbatim.

3. **Test changesets** — Adds changesets for all four monorepo packages (`mdslide-core`, `mdslide-parser`, `mdslide-shared`, `mdslide-cli`) to validate the end-to-end changeset → version bump → publish pipeline.

### Related Issues

- N/A — Infrastructure and CI/CD hardening.

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [x] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `bun run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.

## Screenshots (if applicable)

_N/A — No visible UI changes. This PR affects CI/CD workflows and a build-time script only._

## Additional Context

- The `concurrency` block uses `cancel-in-progress: false` intentionally. For release workflows, cancelling an in-flight run risks leaving packages in a partially published state. Queuing is the safer behavior.
- The `publishHelper.ts` fix introduces a `rawContent` field in `getPackagesInfo()` that stores the original `package.json` string before parsing. The backup (`package.json.bak`) now writes this raw string instead of a re-serialized version, ensuring byte-for-byte restore fidelity.
- **Important:** The included test changesets will trigger real patch version bumps and npm publishes when merged to `main`. Confirm this is the intended behavior, or remove the changeset files before merging if this was solely for pipeline validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **CLI**
  - Added a changeset for `@mindfiredigital/mdslide-cli` to validate the publish/versioning flow.

- **Core rendering engine**
  - Added a patch changeset for `@mindfiredigital/mdslide-core` as part of the versioning pipeline validation.

- **Parser**
  - Added a patch changeset for `@mindfiredigital/mdslide-parser`.

- **Shared packages**
  - Added a patch changeset for `@mindfiredigital/mdslide-shared`.

- **Tooling/CI**
  - Updated the release workflow to support manual `workflow_dispatch` runs.
  - Added concurrency control so matching release runs queue instead of cancelling in-progress jobs.
  - Fixed `scripts/publishHelper.ts` to preserve the original `package.json` contents verbatim during `--prepare`, preventing formatting drift in restore backups.

Breaking changes: None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->