### PR TITLE
Feat/release docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,60 @@
+name: Deploy Docs Workflow
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'mdslide-docs/**'
+
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    name: Build & Deploy Docs
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: |
+          cd mdslide-docs
+          bun install
+
+      - name: Build Docusaurus Site
+        run: |
+          cd mdslide-docs
+          bun run build
+
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: mdslide-docs/build
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,8 @@ jobs:
         with:
           publish: bun run release
           version: bun run version
-          commit: 'chore: version packages'
-          title: 'chore: version packages'
+          commit: 'chore(root): version packages'
+          title: 'chore(root): version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Pull Request Title

Add the release docs workflow for docs of the Dockasaruas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Tooling/CI
- Added a new GitHub Pages deploy workflow for the Docusaurus docs site, triggered on pushes to `main` when `mdslide-docs/**` changes and via manual dispatch.
- Configured the workflow with Pages/OIDC permissions, Bun-based install/build steps, artifact upload from `mdslide-docs/build`, and deployment via `actions/deploy-pages`.
- Updated the release workflow’s Changesets commit/title text to use `chore(root): version packages`.

Breaking changes: None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->