### PR TITLE
fix(ci): align release workflow commit messages with commitlint scope convention*

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,8 @@ jobs:
         with:
           publish: bun run release
           version: bun run version
-          commit: 'chore: version packages'
-          title: 'chore: version packages'
+          commit: 'chore(root): version packages'
+          title: 'chore(root): version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### What does this PR do?

Fixes the release pipeline's auto-generated commit message and PR title to comply with the project's commitlint configuration.

The `changesets/action` in the release workflow was using `'chore: version packages'` for both the commit message and the PR title. This format violates the project's commitlint rules, which require a **scope** in conventional commits (e.g., `chore(root): ...`).

**Before:**
```yaml
commit: 'chore: version packages'
title: 'chore: version packages'
```

**After:**
```yaml
commit: 'chore(root): version packages'
title: 'chore(root): version packages'
```

Without this fix, the changeset version PR and its merge commit would fail commitlint checks, potentially blocking the pipeline or producing lint warnings in CI.

### Related Issues

- Follows up on PR #105 (pipeline hardening)
- Resolves commitlint failures triggered by the changeset action's auto-generated commits

## Type of Change

- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [x] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `bun run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.

## Screenshots (if applicable)

_N/A — No visible UI changes. This PR affects only the CI/CD release workflow configuration._

## Additional Context

- **Scope of change:** Only 2 lines in `.github/workflows/release.yml` — the `commit` and `title` fields of the `changesets/action` step.
- **Why `root`?** The `root` scope is appropriate here because the changeset version bump affects the monorepo root-level versioning, not a specific package.
- **Risk:** Zero. This only changes the format of auto-generated commit messages and PR titles to include the required scope. No functional behavior is affected.

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Tooling/CI
  - Updated `.github/workflows/release.yml` so Changesets-generated version PRs and commits use `chore(root): version packages` instead of `chore: version packages`.
  - This keeps auto-generated release commits aligned with the repository’s commitlint scope convention and avoids lint failures.

Breaking changes: None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->