### PR TITLE
Fix/layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ When presenting your compiled HTML slides in the browser, you can use the follow
 | `←` (Left Arrow)             | Previous       | Return to the previous slide or sequential item.                                       |
 | `f` / `F`                    | Fullscreen     | Toggle fullscreen mode.                                                                |
 | `p` / `P`                    | Presenter View | Open a synced Presenter View window containing speaker notes and a presentation timer. |
+| `?`                          | Help Guide     | Toggle the keyboard shortcuts overlay cheat sheet.                                     |
 
 ---
 

--- a/mdslide-docs/docs/cli-commands/compile.md
+++ b/mdslide-docs/docs/cli-commands/compile.md
@@ -61,6 +61,7 @@ Compiles your slides into a single, dependency-free HTML file containing all sty
 
 - **Presenter View** (`P`)
 - **Fullscreen Mode** (`F`)
+- **Keyboard Shortcuts Help Guide** (`?`)
 - **Animations & reveals**
 
 ### 2. PDF Output (Print-Ready Document)

--- a/packages/core/src/overflow/index.ts
+++ b/packages/core/src/overflow/index.ts
@@ -109,6 +109,8 @@ export function processOverflow(slides: Slide[]): Slide[] {
         titleAlign: slide.titleAlign,
         titlePosition: slide.titlePosition,
         overflow: slide.overflow,
+        animation: slide.animation,
+        fontSize: slide.fontSize,
       });
 
       continuationCount++;
@@ -217,6 +219,8 @@ export function processOverflow(slides: Slide[]): Slide[] {
         titleAlign: slide.titleAlign,
         titlePosition: slide.titlePosition,
         overflow: slide.overflow,
+        animation: slide.animation,
+        fontSize: slide.fontSize,
       });
     }
   }

--- a/packages/core/src/renderer/html/index.ts
+++ b/packages/core/src/renderer/html/index.ts
@@ -206,21 +206,38 @@ ${slidesHtml}
 
   <!-- DOK Control bar -->
   <div class="dokContainer">
-    <button id="dokPrev" class="dokBtn" title="Previous Slide">
+    <button id="dokPrev" class="dokBtn" title="Previous Slide (&larr;)">
       <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg>
     </button>
     <span id="dokCounter" class="dokCounter">1 / 1</span>
-    <button id="dokNext" class="dokBtn" title="Next Slide">
+    <button id="dokNext" class="dokBtn" title="Next Slide (Space / &rarr;)">
       <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>
     </button>
 
-    <button id="dokPresenter" class="dokBtn" title="Monitor">
+    <button id="dokPresenter" class="dokBtn" title="Presenter Console (P)">
       <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect><line x1="8" y1="21" x2="16" y2="21"></line><line x1="12" y1="17" x2="12" y2="21"></line></svg>
     </button>
     
-    <button id="dokFullscreen" class="dokBtn" title="Toggle Fullscreen (F)">
+    <button id="dokFullscreen" class="dokBtn" title="Fullscreen (F)">
       <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"></path></svg>
     </button>
+  </div>
+
+  <!-- Keyboard Shortcut Help Modal -->
+  <div id="helpModal" class="helpModal">
+    <div class="helpModalContent">
+      <div class="helpModalHeader">
+        <h3>Keyboard Shortcuts</h3>
+        <button id="closeHelpModal" class="closeHelpModalBtn">&times;</button>
+      </div>
+      <div class="helpModalBody">
+        <div class="shortcutRow"><span><span class="key">Space</span> / <span class="key">&rarr;</span></span><span>Next Slide / Fragment</span></div>
+        <div class="shortcutRow"><span><span class="key">&larr;</span></span><span>Previous Slide / Fragment</span></div>
+        <div class="shortcutRow"><span><span class="key">F</span></span><span>Toggle Fullscreen</span></div>
+        <div class="shortcutRow"><span><span class="key">P</span></span><span>Toggle Presenter Console</span></div>
+        <div class="shortcutRow"><span><span class="key">?</span></span><span>Show / Hide Shortcut Guide</span></div>
+      </div>
+    </div>
   </div>
 
   <script src="${urls.prismCoreJs}"></script>

--- a/packages/core/src/renderer/html/script.ts
+++ b/packages/core/src/renderer/html/script.ts
@@ -96,6 +96,8 @@ export const script = `
   const btnNext = document.getElementById('dokNext');
   const btnFullscreen = document.getElementById('dokFullscreen');
   const btnPresenter = document.getElementById('dokPresenter');
+  const helpModal = document.getElementById('helpModal');
+  const btnCloseHelp = document.getElementById('closeHelpModal');
 
   let current = 0;
   let presenterWindow = null;
@@ -209,14 +211,59 @@ export const script = `
 
   // Hndler of the full screen toggle
   function toggleFullscreen() {
-    if (!document.fullscreenElement) {
-      document.documentElement.requestFullscreen?.().catch(function (err) {
-        console.error('Error enabling fullscreen:', err);
-      });
+    const docEl = document.documentElement;
+    const requestFs = docEl.requestFullscreen || 
+                      docEl.webkitRequestFullscreen || 
+                      docEl.mozRequestFullScreen || 
+                      docEl.msRequestFullscreen;
+                      
+    const exitFs = document.exitFullscreen || 
+                   document.webkitExitFullscreen || 
+                   document.mozCancelFullScreen || 
+                   document.msExitFullscreen;
+                   
+    const fsElement = document.fullscreenElement || 
+                      document.webkitFullscreenElement || 
+                      document.mozFullScreenElement || 
+                      document.msFullscreenElement;
+
+    if (!fsElement) {
+      if (requestFs) {
+        try {
+          const promise = requestFs.call(docEl);
+          if (promise && typeof promise.catch === 'function') {
+            promise.catch(function (err) {
+              console.error('Error enabling fullscreen:', err);
+            });
+          }
+        } catch (err) {
+          console.error('Error enabling fullscreen:', err);
+        }
+      }
     } else {
-      document.exitFullscreen();
+      if (exitFs) {
+        exitFs.call(document);
+      }
     }
   }
+
+  function onFullscreenChange() {
+    const fsElement = document.fullscreenElement || 
+                      document.webkitFullscreenElement || 
+                      document.mozFullScreenElement || 
+                      document.msFullscreenElement;
+    if (fsElement) {
+      document.body.classList.add('mdslide-fullscreen');
+    } else {
+      document.body.classList.remove('mdslide-fullscreen');
+    }
+    resizeDeck();
+  }
+
+  document.addEventListener('fullscreenchange', onFullscreenChange);
+  document.addEventListener('webkitfullscreenchange', onFullscreenChange);
+  document.addEventListener('mozfullscreenchange', onFullscreenChange);
+  document.addEventListener('MSFullscreenChange', onFullscreenChange);
 
   // Handler of presenter window toggling
   function togglePresenterWindow() {
@@ -357,14 +404,28 @@ export const script = `
       toggleFullscreen();
     } else if (e.key === 'p' || e.key === 'P') {
       togglePresenterWindow();
+    } else if (e.key === '?') {
+      toggleHelp();
     }
   });
+
+  function toggleHelp() {
+    if (helpModal) {
+      helpModal.classList.toggle('visible');
+    }
+  }
 
   // Floating DOK Display Vislibility on Mouse Move
   if (btnPrev) btnPrev.addEventListener('click', triggerPrev);
   if (btnNext) btnNext.addEventListener('click', triggerNext);
   if (btnFullscreen) btnFullscreen.addEventListener('click', toggleFullscreen);
   if (btnPresenter) btnPresenter.addEventListener('click', togglePresenterWindow);
+  if (btnCloseHelp) btnCloseHelp.addEventListener('click', toggleHelp);
+  if (helpModal) {
+    helpModal.addEventListener('click', function (e) {
+      if (e.target === helpModal) toggleHelp();
+    });
+  }
 
   // Floating DOK Display Visibility on Mouse Move
   let hudTimeout;

--- a/packages/core/src/renderer/html/script.ts
+++ b/packages/core/src/renderer/html/script.ts
@@ -72,8 +72,8 @@ export const script = `
 
     const width = 1920;
     const height = 1080;
-    const windowWidth = window.innerWidth;
-    const windowHeight = window.innerHeight;
+    const windowWidth = window.innerWidth || document.documentElement.clientWidth;
+    const windowHeight = window.innerHeight || document.documentElement.clientHeight;
 
     const scale = Math.min(windowWidth / width, windowHeight / height);
 
@@ -145,6 +145,17 @@ export const script = `
     // Update activeFragments for the current slide
     const currentSlide = slides[index];
     if (currentSlide) {
+      // Sync body background image with current slide for seamless fullscreen coverage
+      const bgImg = currentSlide.style.backgroundImage;
+      if (bgImg) {
+        document.body.style.backgroundImage = bgImg;
+        document.body.style.backgroundSize = 'cover';
+        document.body.style.backgroundPosition = 'center';
+        document.body.style.backgroundRepeat = 'no-repeat';
+      } else {
+        document.body.style.backgroundImage = '';
+      }
+
       activeFragments = Array.from(currentSlide.querySelectorAll('.fragment'));
       if (direction === 'forward') {
         activeFragments.forEach(function (f) { f.classList.remove('visible'); });
@@ -256,8 +267,15 @@ export const script = `
       document.body.classList.add('mdslide-fullscreen');
     } else {
       document.body.classList.remove('mdslide-fullscreen');
+      document.body.style.backgroundImage = '';
     }
     resizeDeck();
+    
+    // Multiple timeouts to handle animated fullscreen transitions (especially on macOS)
+    setTimeout(resizeDeck, 100);
+    setTimeout(resizeDeck, 300);
+    setTimeout(resizeDeck, 600);
+    setTimeout(resizeDeck, 1000);
   }
 
   document.addEventListener('fullscreenchange', onFullscreenChange);

--- a/packages/core/src/themes/themeEngine.ts
+++ b/packages/core/src/themes/themeEngine.ts
@@ -11,14 +11,16 @@ export class ThemeEngine {
 
 html {
   font-size: 20px;
+  height: 100%;
+  width: 100%;
 }
 
 body {
   font-family: var(--slide-font, 'Inter', system-ui, sans-serif);
   background: var(--slide-bg);
   color: var(--slide-text);
-  height: 100vh;
-  width: 100vw;
+  height: 100%;
+  width: 100%;
   margin: 0;
   padding: 0;
   overflow: hidden;
@@ -816,7 +818,7 @@ body.showDok .dokContainer,
 
 /* Fullscreen mode styling */
 body.mdslide-fullscreen {
-  background: #000000 !important;
+  background-color: var(--slide-bg);
 }
 
 body.mdslide-fullscreen .deck {

--- a/packages/core/src/themes/themeEngine.ts
+++ b/packages/core/src/themes/themeEngine.ts
@@ -84,9 +84,9 @@ body {
 }
 
 .slide[data-type="statement"] {
-  align-items: center;
-  text-align: center;
-  justify-content: center;
+  align-items: flex-start;
+  text-align: left;
+  justify-content: flex-start;
   padding: 6.5rem 9.5rem;
 }
 
@@ -220,23 +220,41 @@ body {
   font-size: 2rem;
   line-height: 1.5;
   font-weight: 500;
-  max-width: 22ch;
+  max-width: 65ch;
 }
 
 /* Lists */
 .slideContent ul,
 .slideContent ol {
-  padding-left: 2rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.8rem;
+  padding-left: 2.2rem;
   margin-bottom: 1rem;
+  text-align: left;
 }
 
 .slideContent li {
   font-size: var(--li-size, 1.3rem);
   line-height: 1.6;
-  padding-left: 0.25rem;
+  margin-bottom: 0.8rem;
+  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1), color 0.2s ease;
+}
+
+.slideContent li:hover {
+  color: var(--slide-accent);
+  transform: translateX(6px);
+}
+
+.slideContent li:last-child {
+  margin-bottom: 0;
+}
+
+.slideContent li li {
+  margin-bottom: 0.4rem;
+}
+
+.deck .slide[data-title-align="center"] .slideContent ul,
+.deck .slide[data-title-align="center"] .slideContent ol {
+  align-self: center;
+  display: inline-block;
 }
 
 .slideContent li::marker {
@@ -386,6 +404,33 @@ body {
   border-radius: var(--slide-radius);
 }
 
+/* Refined Bullets Layout */
+.slide[data-type="bullets"] .slideContent li {
+  font-size: calc(var(--li-size, 1.3rem) * 1.05);
+  margin-bottom: 1.1rem;
+}
+
+/* Refined Code Layout */
+.slide[data-type="code"] .slideContent pre {
+  border: 1px solid var(--slide-accent, rgba(128,128,128,0.2));
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+/* Refined Quote Layout */
+.slide[data-type="quote"] .slideContent blockquote {
+  border-left: 5px solid var(--slide-accent);
+  background: var(--slide-surface, rgba(128, 128, 128, 0.04));
+  padding: 1.75rem 2.5rem;
+  font-size: 1.5rem;
+  border-radius: var(--slide-radius);
+}
+
+/* Refined Table Layout */
+.slide[data-type="table"] .slideContent table {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+  border: 1px solid var(--slide-border, rgba(128, 128, 128, 0.15));
+}
+
 /* Split layout */
 .splitLayout {
   display: flex;
@@ -399,6 +444,7 @@ body {
 .splitColumn {
   flex: 1;
   min-width: 0;
+  text-align: left;
 }
 
 .splitColumn.textColumn {
@@ -520,7 +566,7 @@ body {
   bottom: 0;
   left: 0;
   width: 100%;
-  height: 4px;
+  height: 5px;
   background: var(--progress-bg, rgba(0,0,0,0.06));
   z-index: 200;
 }
@@ -528,7 +574,8 @@ body {
 .progressBar {
   height: 100%;
   width: 0%;
-  background: var(--slide-accent);
+  background: linear-gradient(90deg, var(--slide-accent), #f43f5e);
+  box-shadow: 0 0 10px var(--slide-accent);
   transition: width 0.35s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
@@ -538,10 +585,10 @@ body {
   bottom: 1.75rem;
   left: 50%;
   transform: translateX(-50%) translateY(72px);
-  background: var(--dok-bg, rgba(255,255,255,0.85));
+  background: var(--dok-bg, rgba(255,255,255,0.88));
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
-  border: 1px solid var(--dok-border, rgba(0,0,0,0.1));
+  border: 1px solid var(--dok-border, rgba(0,0,0,0.08));
   border-radius: 100px;
   padding: 0.5rem 1.125rem;
   display: flex;
@@ -549,9 +596,18 @@ body {
   gap: 0.5rem;
   z-index: 199;
   opacity: 0;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.08);
   transition:
     transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
     opacity   0.35s ease-out;
+}
+
+[data-theme="dark"] .dokContainer,
+[data-theme="terminal"] .dokContainer,
+[data-theme="gradient"] .dokContainer {
+  background: var(--dok-bg, rgba(24,24,27,0.85));
+  border: 1px solid var(--dok-border, rgba(255,255,255,0.08));
+  box-shadow: 0 10px 30px rgba(0,0,0,0.3);
 }
 
 body.showDok .dokContainer,
@@ -572,13 +628,18 @@ body.showDok .dokContainer,
   align-items: center;
   justify-content: center;
   opacity: 0.65;
-  transition: background 0.15s, opacity 0.15s;
+  transition: background 0.2s, opacity 0.2s, transform 0.2s;
   flex-shrink: 0;
 }
 
 .dokBtn:hover {
   background: rgba(128,128,128,0.12);
   opacity: 1;
+  transform: scale(1.1);
+}
+
+.dokBtn:active {
+  transform: scale(0.95);
 }
 
 .dokCounter {
@@ -590,6 +651,117 @@ body.showDok .dokContainer,
   opacity: 0.8;
   min-width: 3.5rem;
   text-align: center;
+}
+
+/* Keyboard Shortcut Help Modal */
+.helpModal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 300;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.helpModal.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.helpModalContent {
+  background: var(--slide-surface, #ffffff);
+  border: 1px solid var(--slide-border, rgba(0,0,0,0.1));
+  border-radius: 16px;
+  width: 90%;
+  max-width: 480px;
+  box-shadow: 0 20px 40px rgba(0,0,0,0.15);
+  transform: scale(0.9) translateY(10px);
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+  overflow: hidden;
+  color: var(--slide-text);
+}
+
+[data-theme="dark"] .helpModalContent,
+[data-theme="terminal"] .helpModalContent,
+[data-theme="gradient"] .helpModalContent {
+  background: var(--slide-surface, #1e1e24);
+  border-color: rgba(255,255,255,0.08);
+  box-shadow: 0 20px 40px rgba(0,0,0,0.4);
+}
+
+.helpModal.visible .helpModalContent {
+  transform: scale(1) translateY(0);
+}
+
+.helpModalHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--slide-border, rgba(0,0,0,0.06));
+}
+
+[data-theme="dark"] .helpModalHeader,
+[data-theme="terminal"] .helpModalHeader,
+[data-theme="gradient"] .helpModalHeader {
+  border-bottom-color: rgba(255,255,255,0.06);
+}
+
+.helpModalHeader h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.closeHelpModalBtn {
+  background: transparent;
+  border: none;
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--slide-muted, #71717a);
+  transition: color 0.15s;
+}
+
+.closeHelpModalBtn:hover {
+  color: var(--slide-accent);
+}
+
+.helpModalBody {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.shortcutRow {
+  display: flex;
+  align-items: center;
+  font-size: 0.95rem;
+}
+
+.shortcutRow span:last-child {
+  margin-left: auto;
+  color: var(--slide-muted, #71717a);
+}
+
+.key {
+  background: rgba(128,128,128,0.12);
+  border: 1px solid rgba(128,128,128,0.22);
+  border-radius: 6px;
+  padding: 0.25rem 0.5rem;
+  font-family: var(--slide-mono, monospace);
+  font-size: 0.8rem;
+  font-weight: 600;
+  box-shadow: 0 2px 0 rgba(0,0,0,0.08);
+  margin-right: 0.35rem;
+  color: var(--slide-text);
 }
 
 /* Print PDF */
@@ -640,6 +812,22 @@ body.showDok .dokContainer,
   .fragment {
     opacity: 1 !important;
   }
+}
+
+/* Fullscreen mode styling */
+body.mdslide-fullscreen {
+  background: #000000 !important;
+}
+
+body.mdslide-fullscreen .deck {
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+
+body.mdslide-fullscreen,
+body.mdslide-fullscreen * {
+  -webkit-text-size-adjust: 100% !important;
+  text-size-adjust: 100% !important;
 }
 `;
   }

--- a/packages/core/src/themes/themeEngine.ts
+++ b/packages/core/src/themes/themeEngine.ts
@@ -235,7 +235,7 @@ body {
   font-size: var(--li-size, 1.3rem);
   line-height: 1.6;
   margin-bottom: 0.8rem;
-  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1), color 0.2s ease;
+  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1), color 0.2s ease, opacity 0.3s ease;
 }
 
 .slideContent li:hover {


### PR DESCRIPTION
## Pull Request Title

Fix layouts, attempt macOS full-screen fix, and add hotkey help modal

---

## Description

### What does this PR do?

This PR improves the user interface by resolving layout spacing issues and making a targeted fix for the macOS full-screen button bug. Additionally, it introduces a new help button (`?`) in the document layout (`dok`). Clicking this button opens a modal overlay that maps out all available keyboard shortcuts and application controls for easier navigation.

### Related Issues

- Closes #ISSUE_NUMBER 

## Type of Change

- [x] 🐛 Bug fix
- [x] 🚀 New feature
- [ ] 📄 Documentation update
- [x] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

- [x] I have linted my code using `bun run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.

## Screenshots (if applicable)

_Provide screenshots or GIFs if this PR changes has visible results._

## Additional Context

- Added global CSS updates to fix the misaligned layout components.
- Implemented event listeners for the `?` hotkey to toggle the help modal.
- Adjusted window resizing handling specifically targeted at Safari/macOS native full-screen triggers.

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- **CLI**
  - Updated the published navigation/help documentation to include the new `?` keyboard shortcut for opening the help guide.
  - Added compile-command docs noting the keyboard shortcuts help overlay.

- **Core rendering engine**
  - Added a new in-deck keyboard shortcuts help modal, including UI copy, close handling, and backdrop dismissal.
  - Updated embedded HTML control labels and presenter button text.
  - Improved fullscreen handling for macOS/Safari/native fullscreen triggers with vendor-prefixed fallbacks, fullscreen state tracking, and resize handling on fullscreen changes.
  - Preserved `animation` and `fontSize` when generating overflow continuation and final slides.
  - Refreshed base theme CSS for layout spacing, statement/list styling, split layouts, progress bar appearance, DOK controls, modal styling, and fullscreen mode presentation.

Breaking changes: None
<!-- end of auto-generated comment: release notes by coderabbit.ai -->