### PR TITLE
feat: Add SYNTAX.md rules and `mdslide llms` command for AI agent context integration

### DIFF
--- a/.github/workflows/auto-changeset.yml
+++ b/.github/workflows/auto-changeset.yml
@@ -1,0 +1,39 @@
+name: Auto Changeset Generator
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  auto-changeset:
+    name: Auto Generate Changeset
+    runs-on: ubuntu-latest
+
+    # Skip commits made by github-actions bot to prevent loops
+    if: "!contains(github.event.head_commit.author.name, 'github-actions')"
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run Auto Changeset Script
+        run: bun run auto-changeset
+
+      - name: Commit and Push Changeset
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(config): automatically generate changeset for conventional commit"
+          file_pattern: ".changeset/*.md"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "version": "changeset version",
     "release": "bun run build && bun run scripts/publishHelper.ts --publish",
     "changeset": "changeset",
+    "auto-changeset": "bun run scripts/autoChangeset.ts",
     "docs:build": "bun run --cwd mdslide-docs build",
     "docs:start": "bun run --cwd mdslide-docs start"
   },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,6 +5,7 @@ import { compileCommand } from './commands/compile.js';
 import { watchCommand } from './commands/watch.js';
 import { initCommand } from './commands/init.js';
 import { validateCommand } from './commands/validate.js';
+import { llmsCommand } from './commands/llms.js';
 import { runInteractivePrompt } from './interactiveCommands/index.js';
 import { Logger } from './logger/index.js';
 import { icons } from './assets/index.js';
@@ -137,6 +138,18 @@ cli
       strict: opts.strict ?? false,
       logLevel: opts.verbose ? 'verbose' : opts.silent ? 'silent' : 'info',
     }).catch(() => process.exit(1));
+  });
+
+// llms
+cli
+  .command(
+    'llms',
+    'Print the complete Markdown syntax & CLI reference as plain markdown (for AI agents & LLMs)'
+  )
+  .example('  mdslide llms')
+  .example('  mdslide llms > SYNTAX.md')
+  .action(() => {
+    llmsCommand();
   });
 
 // interactive

--- a/packages/cli/src/commands/llms.ts
+++ b/packages/cli/src/commands/llms.ts
@@ -1,0 +1,8 @@
+import syntaxReference from '../docs/SYNTAX.md';
+
+// Plain markdown to stdout, no logger/ANSI decoration: the output is meant to
+// be captured into an AI agent's context or piped to a file.
+export function llmsCommand(): void {
+  const text = syntaxReference.endsWith('\n') ? syntaxReference : `${syntaxReference}\n`;
+  process.stdout.write(text);
+}

--- a/packages/cli/src/docs/SYNTAX.md
+++ b/packages/cli/src/docs/SYNTAX.md
@@ -1,0 +1,548 @@
+# mdslide — Complete Syntax & CLI Reference
+
+> This is the canonical, self-contained reference for authoring and building
+> presentations with `mdslide`. It is written so that a human — or an AI agent
+> with no other context — can create, update, and export a full slide deck
+> from scratch. Print it any time with `mdslide llms`.
+
+`mdslide` compiles a single standard Markdown (`.md`) file into an interactive
+slide deck exported as **HTML**, **PDF**, or **PowerPoint (PPTX)**. You never
+touch a GUI: author Markdown, run the CLI.
+
+---
+
+## Recommended Workflow (for AI agents)
+
+1. **Write** a `slides.md` file using the syntax below.
+2. **Validate**: `mdslide validate slides.md` — fix any overflow or annotation
+   warnings it reports before delivering.
+3. **Preview or export**:
+   - Live preview with hot-reload: `mdslide watch slides.md --port 3500 --open`
+   - Standalone HTML: `mdslide compile slides.md -o deck.html`
+   - PDF: `mdslide compile slides.md -o deck.pdf`
+   - PowerPoint: `mdslide compile slides.md -o deck.pptx --pptx-mode editable`
+4. **Update**: edit the Markdown file, re-run `validate`, recompile. If a
+   `watch` server is running, saving the file hot-reloads the browser
+   automatically — no restart needed.
+
+Avoid running bare `mdslide slides.md` in automated contexts: it launches an
+interactive wizard that requires a human at the keyboard. Always use the
+explicit `compile` / `watch` / `validate` subcommands with flags.
+
+---
+
+## 1. Presentation File Structure
+
+A presentation is one Markdown file with three kinds of building blocks:
+
+```markdown
+---
+title: My Deck # ← 1. YAML frontmatter: global defaults (optional)
+theme: gradient
+---
+
+<!-- layout: title -->    # ← 3. HTML comment annotations: per-slide overrides
+
+# First Slide
+
+--- # ← 2. Slide separator: `---` on its own empty line
+
+## Second Slide
+
+- Content here
+```
+
+### Slide separation
+
+- **Explicit (recommended)**: three dashes `---` on an empty line start a new
+  slide.
+- **Auto-separation**: if the file contains no `---` dividers, the compiler
+  automatically starts a new slide at every Level-2 heading (`##`).
+
+---
+
+## 2. Global Frontmatter (applies to all slides)
+
+Optional YAML block between `---` boundaries at the very top of the file:
+
+```yaml
+---
+title: Product Kickoff 2026
+theme: gradient
+titleAlign: center
+titlePosition: top
+animation: slide-up
+overflow: split
+---
+```
+
+| YAML Key                 | Allowed Values                                                              | Description                                                        |
+| :----------------------- | :-------------------------------------------------------------------------- | :----------------------------------------------------------------- |
+| `title`                  | Any text                                                                    | Presentation title (used in compiled HTML metadata).               |
+| `theme`                  | `light`, `dark`, `notion`, `terminal`, `gradient`, `corporate`, `solarized` | Overall visual theme and color scheme. Global only.                |
+| `titleAlign`             | `left`, `center`, `right`                                                   | Default horizontal alignment for slide titles.                     |
+| `titlePosition`          | `top`, `center`, `bottom`                                                   | Default vertical position for slide titles.                        |
+| `animation` (or `build`) | `fade`, `slide-up`, `slide-left`, `slide-right`, `zoom`                     | Default step-by-step reveal animation for list items and images.   |
+| `overflow`               | `split`, `none`                                                             | Enables/disables the auto-splitting engine for overflowing slides. |
+
+Frontmatter values are **defaults**; any slide can override them locally with
+a comment annotation (below). The slide-level value always wins for that slide.
+
+---
+
+## 3. Per-Slide Comment Annotations
+
+Place standard HTML comments inside a slide (typically near the top) to
+override settings for that slide only:
+
+```markdown
+# Target Metrics
+
+<!-- titleAlign: center -->
+<!-- animation: zoom -->
+
+- Metric A
+- Metric B
+```
+
+| Annotation                           | Allowed Values                                                               | Description                                            |
+| :----------------------------------- | :--------------------------------------------------------------------------- | :----------------------------------------------------- |
+| `<!-- layout: value -->`             | `title`, `bullets`, `code`, `visual`, `quote`, `table`, `statement`, `split` | Force a specific layout for this slide.                |
+| `<!-- titleAlign: value -->`         | `left`, `center`, `right`                                                    | Horizontal title alignment for this slide.             |
+| `<!-- titlePosition: value -->`      | `top`, `center`, `bottom`                                                    | Vertical title placement for this slide.               |
+| `<!-- animation: value -->`          | `fade`, `slide-up`, `slide-left`, `slide-right`, `zoom`                      | Reveal animation for this slide's list items/elements. |
+| `<!-- overflow: value -->`           | `split`, `none`                                                              | Enable/disable auto-splitting for this slide only.     |
+| `<!-- backgroundImage: ... -->`      | `url('...')` optionally followed by `dark` or `light`                        | Full-bleed background image (see §5).                  |
+| `<!-- notes --> ... <!-- /notes -->` | Any text between the markers                                                 | Speaker notes shown only in Presenter View (see §6).   |
+
+---
+
+## 4. Slide Layouts
+
+The layout engine auto-detects a fitting layout from content, but you can
+force one with `<!-- layout: name -->`:
+
+| Layout      | Use case                       | Style                                                     |
+| :---------- | :----------------------------- | :-------------------------------------------------------- |
+| `title`     | Cover slide, section headers   | Title + subtitle centered, extra-large fonts.             |
+| `bullets`   | Bulleted summaries             | Larger list typography, accent markers, generous margins. |
+| `code`      | Full-screen source code        | Code block fills the slide, optimized typography.         |
+| `visual`    | Prominent images/screenshots   | Image stretched to maximum area, heading kept neat.       |
+| `quote`     | Testimonials, key takeaways    | Quote centered in a highlighted glassmorphic card.        |
+| `table`     | Comparison grids               | Table centered vertically and horizontally.               |
+| `statement` | One big statistic or statement | Single short sentence in a massive font.                  |
+| `split`     | Two-column comparisons         | Side-by-side columns (pairs with `::split::`, see below). |
+
+### Layout examples
+
+```markdown
+<!-- layout: title -->
+
+# My Presentation Title
+
+## A compelling subtitle
+```
+
+```markdown
+<!-- layout: quote -->
+
+> "Make it work, make it right, make it fast."
+>
+> - Kent Beck
+```
+
+```markdown
+<!-- layout: statement -->
+
+10× faster than traditional tools.
+```
+
+### Two-column splits (`::split::`)
+
+Partition any slide into two equal columns by placing `::split::` alone on an
+empty line (blank lines before AND after it are required — otherwise it is
+treated as body text and ignored):
+
+```markdown
+# Front-end vs Back-end
+
+### Front-end
+
+- React / Next.js
+- Tailwind CSS
+
+::split::
+
+### Back-end
+
+- Node.js / Bun
+- PostgreSQL / Redis
+```
+
+### Auto-split heuristic (text + image)
+
+If a slide contains **exactly one image** plus text and no manual `::split::`,
+the compiler automatically renders a two-column layout: text on the left,
+image fitted on the right. To avoid this, force a layout explicitly.
+
+---
+
+## 5. Background Images
+
+```markdown
+# Skyrocket Sales
+
+<!-- backgroundImage: url('https://example.com/growth.jpg') -->
+```
+
+- **Luminance auto-detection**: dark images flip slide text to white; light
+  images keep dark text with subtle drop shadows.
+- **Manual override**: append `dark` or `light` inside the comment to force
+  the contrast theme:
+
+```markdown
+<!-- backgroundImage: url('dark-forest.jpg') dark -->
+<!-- backgroundImage: url('snowy-mountain.jpg') light -->
+```
+
+---
+
+## 6. Speaker Notes
+
+Text between `<!-- notes -->` and `<!-- /notes -->` is hidden from the main
+presentation and shown only in the Presenter View window (opened with `P`),
+alongside a presentation timer:
+
+```markdown
+# Q3 Financial Summary
+
+- Revenue up 15%
+- Net profit up 8%
+
+<!-- notes -->
+
+Emphasize that profit growth came from the new licensing model.
+Expect questions about marketing costs.
+
+<!-- /notes -->
+```
+
+---
+
+## 7. Advanced Content (Math, Diagrams, GFM)
+
+All supported out of the box — no plugins or configuration:
+
+- **Inline math (KaTeX)**: `The theorem is $a^2 + b^2 = c^2$.`
+- **Block math**: wrap LaTeX in `$$ ... $$` on separate lines for a centered
+  equation.
+- **Mermaid diagrams**: fenced code block with the `mermaid` language tag —
+  flowcharts, sequence diagrams, state charts, Gantt timelines:
+
+  ````markdown
+  ```mermaid
+  graph TD
+      A[Markdown File] --> B(mdslide Compiler)
+      B --> C{Output Format}
+  ```
+  ````
+
+- **GitHub Flavored Markdown**: tables (`| a | b |`), task lists (`- [x]`),
+  and strikethrough (`~~text~~`).
+
+---
+
+## 8. Custom Styling (CSS Variables)
+
+Add a `<style>` block (conventionally at the bottom of the file) and override
+CSS variables on `:root`:
+
+```html
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;700&display=swap');
+
+  :root {
+    --slide-font: 'Outfit', sans-serif; /* main font family */
+    --slide-mono: 'Fira Code', monospace; /* code font family */
+    --slide-bg: #0f172a; /* slide background */
+    --slide-text: #f8fafc; /* body text and headings */
+    --slide-accent: #f43f5e; /* links, bullet markers, borders */
+    --slide-radius: 10px; /* card/code/image border radius */
+  }
+</style>
+```
+
+| Variable          | Purpose                                                   |
+| :---------------- | :-------------------------------------------------------- |
+| `--slide-font`    | Main font family (headings, lists, paragraphs, cards).    |
+| `--slide-mono`    | Font family for code blocks and inline code.              |
+| `--title-size`    | Primary slide title size (default `3.6rem`).              |
+| `--h2-size`       | Secondary heading size (default `2.6rem`).                |
+| `--h3-size`       | Tertiary heading size (default `1.8rem`).                 |
+| `--body-size`     | Paragraph text size (default `1.35rem`).                  |
+| `--li-size`       | List item size (default `1.3rem`).                        |
+| `--code-size`     | Code block font size (default `1.1rem`).                  |
+| `--slide-bg`      | Slide background color.                                   |
+| `--slide-surface` | Background for quote boxes, code blocks, cards.           |
+| `--slide-text`    | Main body text and heading color.                         |
+| `--slide-muted`   | Footnotes, captions, muted elements.                      |
+| `--slide-accent`  | Accent color: link underlines, bullet markers, borders.   |
+| `--slide-border`  | Divider lines and card borders.                           |
+| `--slide-radius`  | Border radius for cards, code containers, images (`6px`). |
+
+---
+
+## 9. CLI Command Reference
+
+### Discovering commands and flags at runtime
+
+The tables below document every command and flag, but the CLI itself is
+always the authoritative source for the **installed** version. To
+self-discover at runtime:
+
+```bash
+mdslide --help              # list all commands
+mdslide compile --help      # full flag reference for one command
+mdslide watch --help        # (works for every subcommand: compile, watch,
+mdslide validate --help     #  init, validate, interactive)
+mdslide --version           # installed CLI version
+mdslide llms                # reprint this entire reference
+```
+
+If a flag in this document is rejected by the CLI, or you need an option not
+listed here, run `mdslide <command> --help` and trust that output — it always
+matches the binary you are running.
+
+### `mdslide compile <input> [options]` — build a distributable file
+
+| Flag                     | Short | Default             | Description                                                                 |
+| :----------------------- | :---- | :------------------ | :-------------------------------------------------------------------------- |
+| `--theme <theme>`        | `-t`  | `light`             | `light`, `dark`, `notion`, `terminal`, `gradient`, `corporate`, `solarized` |
+| `--output <file>`        | `-o`  | `output.<format>`   | Output file path.                                                           |
+| `--format <format>`      | `-f`  | auto from extension | `html`, `pdf`, or `pptx`.                                                   |
+| `--pptx-mode <mode>`     |       | `screenshot`        | `screenshot` (pixel-perfect images) or `editable` (native PPTX shapes).     |
+| `--open`                 |       | `false`             | Open the compiled file when done.                                           |
+| `--strict`               |       | `false`             | Exit with an error code if validation warnings are found.                   |
+| `--verbose` / `--silent` |       | `false`             | More / no console output.                                                   |
+
+Notes:
+
+- PDF and PPTX-screenshot exports require a local Chrome/Chromium install
+  (headless browser rendering). A custom binary path can be set via
+  `pdf.chromePath` in the config file.
+- `--pptx-mode screenshot` preserves exact visual styling as images;
+  `--pptx-mode editable` produces native, editable PowerPoint text/shapes.
+
+### `mdslide watch <input> [options]` — live dev server with hot-reload
+
+| Flag              | Short | Default | Description                    |
+| :---------------- | :---- | :------ | :----------------------------- |
+| `--port <port>`   | `-p`  | `3500`  | Dev server port.               |
+| `--theme <theme>` | `-t`  | config  | Theme override during preview. |
+| `--open`          |       | `false` | Open the browser on startup.   |
+
+Saving the Markdown file recompiles and refreshes the browser automatically
+via WebSocket — no restart needed between edits.
+
+### `mdslide validate <input> [options]` — lint the deck
+
+Checks frontmatter key/value validity, comment-annotation syntax, layout
+compatibility (e.g. splitting a `title` slide), and **visual overflow**
+(content exceeding slide height). Use `--strict` to turn warnings into a
+non-zero exit code. Always run this after writing or updating a deck.
+
+### `mdslide init [--force]` — scaffold a project
+
+Creates an annotated sample `slides.md` (demonstrating layouts, animations,
+split columns, math, code) and an `mdslide.config.ts` config file. `--force`
+overwrites existing files. Reading the generated `slides.md` is a fast way to
+learn the syntax by example.
+
+### `mdslide <input>` / `mdslide interactive <input>` — interactive wizard
+
+Guided prompts for theme, format, output path, and watch mode. **Requires a
+human at the terminal** — automated tools should use `compile`/`watch` instead.
+
+---
+
+## 10. Project Config File (`mdslide.config.ts`)
+
+Optional; sets project-wide defaults so CLI flags can be omitted:
+
+```typescript
+import { defineConfig } from '@mindfiredigital/mdslide-cli';
+
+export default defineConfig({
+  theme: 'gradient', // default theme
+  output: 'dist/presentation.html', // default output path
+  format: 'html', // 'html' | 'pdf' | 'pptx'
+  watch: { port: 4200, open: true },
+  pdf: { printBackground: true, chromePath: undefined },
+});
+```
+
+CLI flags always override config file values.
+
+---
+
+## 11. Presentation Controls (compiled HTML)
+
+| Key           | Action                                               |
+| :------------ | :--------------------------------------------------- |
+| `Space` / `→` | Next slide (or reveal next animated bullet/element). |
+| `←`           | Previous slide or element.                           |
+| `F`           | Toggle fullscreen.                                   |
+| `P`           | Open synced Presenter View (notes + timer).          |
+| `?`           | Keyboard shortcuts overlay.                          |
+
+---
+
+## 12. Complete Example Deck
+
+A compact deck exercising every major feature — useful as a starting template:
+
+````markdown
+---
+title: Quarterly Review
+theme: gradient
+titleAlign: center
+animation: slide-up
+overflow: split
+---
+
+<!-- layout: title -->
+
+# Quarterly Review
+
+## Q3 2026 · Engineering
+
+---
+
+## Agenda
+
+<!-- layout: bullets -->
+
+- Shipping highlights
+- Performance numbers
+- Architecture changes
+- Next quarter
+
+<!-- notes -->
+
+Keep this under one minute; details come later.
+
+<!-- /notes -->
+
+---
+
+<!-- layout: statement -->
+
+Deploy frequency up 3× this quarter.
+
+---
+
+## Old vs New Pipeline
+
+<!-- layout: split -->
+
+### Before
+
+- Manual releases
+- 40-min builds
+
+::split::
+
+### After
+
+- Continuous deploys
+- 6-min builds
+
+---
+
+<!-- layout: code -->
+
+## The Core Change
+
+```typescript
+export async function deploy(target: Env): Promise<Result> {
+  const build = await compile({ cache: true });
+  return release(build, target);
+}
+```
+
+---
+
+## Request Flow
+
+```mermaid
+graph LR
+    A[Client] --> B(Edge Cache)
+    B --> C{Hit?}
+    C -->|yes| D[Serve]
+    C -->|no| E[Origin]
+```
+
+---
+
+## Latency Model
+
+Response time follows $t = t_0 + \frac{n}{k}$ where:
+
+$$
+k = \text{throughput per worker}
+$$
+
+---
+
+<!-- layout: quote -->
+
+> "The best performance improvement is the transition from the nonworking
+> state to the working state."
+>
+> - John Ousterhout
+
+---
+
+## Results
+
+<!-- layout: table -->
+
+| Metric     | Q2  | Q3  |
+| :--------- | :-- | :-- |
+| P50 (ms)   | 210 | 90  |
+| Deploys/wk | 4   | 12  |
+
+---
+
+## Thank You
+
+<!-- backgroundImage: url('https://example.com/team.jpg') dark -->
+<!-- titlePosition: center -->
+
+Questions?
+````
+
+Build it:
+
+```bash
+mdslide validate slides.md
+mdslide compile slides.md --theme gradient -o review.html --open
+```
+
+---
+
+## 13. Authoring Guidelines (what makes a deck good)
+
+- **One idea per slide.** Prefer more slides over crowded ones; the validator
+  flags overflow, but tight slides read better even when they fit.
+- Start with a `layout: title` cover slide; use `layout: statement` slides to
+  punctuate sections with a single key number or claim.
+- Use `::split::` (or the one-image auto-split) instead of cramming a
+  paragraph next to an image.
+- Put talking points in `<!-- notes -->` blocks, not on the slide.
+- Enable `overflow: split` globally when content length is unpredictable
+  (e.g. generated content); the engine creates numbered continuation slides.
+- Prefer frontmatter for deck-wide choices and comment annotations only for
+  true exceptions — fewer overrides means a more consistent deck.
+- Finish every authoring or update pass with `mdslide validate <file>` and
+  fix all warnings before delivering.

--- a/packages/cli/src/types/markdown.d.ts
+++ b/packages/cli/src/types/markdown.d.ts
@@ -1,0 +1,4 @@
+declare module '*.md' {
+  const content: string;
+  export default content;
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -6,4 +6,5 @@ export default defineConfig({
   entry: ['src/cli.ts', 'src/index.ts'],
   splitting: true,
   dts: true,
+  loader: { '.md': 'text' },
 });

--- a/scripts/autoChangeset.ts
+++ b/scripts/autoChangeset.ts
@@ -1,0 +1,231 @@
+import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+
+export function parseCommitMessage(params: {
+  fullMessage: string;
+  changedPackages: Set<string>;
+  packages: { dirName: string; packageName: string }[];
+}): { packageBumps: Map<string, 'major' | 'minor' | 'patch'>; descriptions: string[] } {
+  const lines = params.fullMessage.split('\n');
+  const packageBumps = new Map<string, 'major' | 'minor' | 'patch'>();
+  const descriptions: string[] = [];
+
+  for (const rawLine of lines) {
+    let line = rawLine.trim();
+    // Strip common bullet list markers or numbering
+    line = line.replace(/^[-*+]\s+/, '');
+    line = line.replace(/^\d+\.\s+/, '');
+
+    const match = line.match(
+      /^(feat|fix|refactor|docs|style|test|chore|perf|ci|build)(?:\(([^)]+)\))?(!?): (.+)/i
+    );
+    if (!match) continue;
+
+    const [_, type, scope, breaking, desc] = match;
+    const isLineBreaking = !!breaking || line.includes('BREAKING CHANGE');
+
+    let lineChangeType: 'major' | 'minor' | 'patch' | null = null;
+    if (isLineBreaking) {
+      lineChangeType = 'major';
+    } else if (type.toLowerCase() === 'feat') {
+      lineChangeType = 'minor';
+    } else if (type.toLowerCase() === 'fix') {
+      lineChangeType = 'patch';
+    }
+
+    if (!lineChangeType) continue; // Skip chore, docs, refactor unless marked as breaking
+
+    const targetPackages = new Set<string>();
+    if (scope) {
+      // Resolve scope to a package name (matching either dirName or packageName suffix)
+      const matched = params.packages.find(
+        (p) =>
+          p.dirName.toLowerCase() === scope.toLowerCase() ||
+          p.packageName.toLowerCase().endsWith(scope.toLowerCase())
+      );
+      if (matched && params.changedPackages.has(matched.packageName)) {
+        targetPackages.add(matched.packageName);
+      }
+    }
+
+    // Fallback: if no scope matches any changed package, apply the bump to all changed packages
+    if (targetPackages.size === 0) {
+      params.changedPackages.forEach((p) => targetPackages.add(p));
+    }
+
+    // Update package bump levels, keeping the highest level: major > minor > patch
+    targetPackages.forEach((pkgName) => {
+      const currentBump = packageBumps.get(pkgName);
+      if (!currentBump) {
+        packageBumps.set(pkgName, lineChangeType!);
+      } else if (lineChangeType === 'major') {
+        packageBumps.set(pkgName, 'major');
+      } else if (lineChangeType === 'minor' && currentBump !== 'major') {
+        packageBumps.set(pkgName, 'minor');
+      }
+    });
+
+    descriptions.push(`${scope ? scope + ': ' : ''}${desc.trim()}`);
+  }
+
+  return { packageBumps, descriptions };
+}
+
+const isRunDirectly =
+  typeof process !== 'undefined' &&
+  process.argv[1] &&
+  /autoChangeset\.[jt]s$/.test(process.argv[1]);
+
+if (isRunDirectly) {
+  // Get workspace packages
+  const PACKAGES_DIR = join(import.meta.dirname, '..', 'packages');
+  const packages = readdirSync(PACKAGES_DIR, { withFileTypes: true })
+    .filter(
+      (entry) => entry.isDirectory() && existsSync(join(PACKAGES_DIR, entry.name, 'package.json'))
+    )
+    .map((entry) => {
+      const pkgJson = JSON.parse(
+        readFileSync(join(PACKAGES_DIR, entry.name, 'package.json'), 'utf8')
+      );
+      return {
+        dirName: entry.name,
+        packageName: pkgJson.name,
+      };
+    });
+
+  // Get latest commit info
+  let commitHash = '';
+  let commitSubject = '';
+  let commitBody = '';
+  let fullMessage = '';
+
+  try {
+    commitHash = execSync('git rev-parse --short HEAD').toString().trim();
+    commitSubject = execSync('git log -1 --format=%s').toString().trim();
+    commitBody = execSync('git log -1 --format=%b').toString().trim();
+    fullMessage = execSync('git log -1 --format=%B').toString().trim();
+  } catch (error) {
+    console.error('Error reading git commit info:', error);
+    process.exit(1);
+  }
+
+  console.log(`Processing commit message: "${commitSubject}" (hash: ${commitHash})`);
+
+  // Check if changeset for this commit already exists
+  const changesetDir = join(import.meta.dirname, '..', '.changeset');
+  const outputFilePath = join(changesetDir, `auto-${commitHash}.md`);
+
+  if (existsSync(outputFilePath)) {
+    console.log(
+      `Changeset for commit ${commitHash} already exists at ${outputFilePath}, skipping.`
+    );
+    process.exit(0);
+  }
+
+  // Get list of modified files in the latest commit
+  let modifiedFiles: string[] = [];
+  try {
+    modifiedFiles = execSync('git diff-tree --no-commit-id --name-only -r HEAD')
+      .toString()
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+  } catch (error) {
+    console.error('Error getting modified files from git:', error);
+    process.exit(1);
+  }
+
+  // Skip if the commit itself already contains a changeset file
+  const hasChangesetInCommit = modifiedFiles.some(
+    (file) => file.startsWith('.changeset/') && file.endsWith('.md') && !file.endsWith('README.md')
+  );
+  if (hasChangesetInCommit) {
+    console.log('Changeset already exists in the latest commit, skipping generation.');
+    process.exit(0);
+  }
+
+  // Identify which packages were changed in the latest commit
+  const changedPackages = new Set<string>();
+  for (const file of modifiedFiles) {
+    if (file.startsWith('packages/')) {
+      const parts = file.split('/');
+      const dirName = parts[1];
+      const matched = packages.find((p) => p.dirName === dirName);
+      if (matched) {
+        changedPackages.add(matched.packageName);
+      }
+    }
+  }
+
+  if (changedPackages.size === 0) {
+    console.log(
+      'No workspace packages were modified in the latest commit. Skipping changeset generation.'
+    );
+    process.exit(0);
+  }
+
+  const { packageBumps, descriptions } = parseCommitMessage({
+    fullMessage,
+    changedPackages,
+    packages,
+  });
+
+  if (packageBumps.size > 0) {
+    const frontmatter = Array.from(packageBumps.entries())
+      .map(([pkgName, bump]) => `'${pkgName}': ${bump}`)
+      .join('\n');
+
+    const changesetContent = `---
+${frontmatter}
+---
+
+${descriptions.join('\n')}
+`;
+
+    if (!existsSync(changesetDir)) {
+      mkdirSync(changesetDir, { recursive: true });
+    }
+
+    writeFileSync(outputFilePath, changesetContent, 'utf8');
+    console.log(
+      `Changeset created successfully at ${outputFilePath} for packages:\n${Array.from(
+        packageBumps.entries()
+      )
+        .map(([pkg, bump]) => `  - ${pkg} (${bump})`)
+        .join('\n')}`
+    );
+  } else {
+    // Safe Fallback: Generate a patch bump for all modified packages to prevent missed releases
+    console.warn(
+      'Warning: No valid release-triggering conventional commits were parsed from the commit message.'
+    );
+    console.warn(
+      'Generating a fallback patch changeset for all modified packages to prevent missed releases.'
+    );
+
+    const fallbackDescription = commitSubject || 'No description provided.';
+    const frontmatter = Array.from(changedPackages)
+      .map((pkgName) => `'${pkgName}': patch`)
+      .join('\n');
+
+    const changesetContent = `---
+${frontmatter}
+---
+
+${fallbackDescription}
+`;
+
+    if (!existsSync(changesetDir)) {
+      mkdirSync(changesetDir, { recursive: true });
+    }
+
+    writeFileSync(outputFilePath, changesetContent, 'utf8');
+    console.log(
+      `Fallback changeset created successfully at ${outputFilePath} for packages: ${Array.from(
+        changedPackages
+      ).join(', ')} (patch)`
+    );
+  }
+}


### PR DESCRIPTION
## Description

### What does this PR do?

This PR introduces a dedicated guidelines file and a new CLI command to optimize `mdslide` for AI agents:
1. **Created `SYNTAX.md`**: A comprehensive rulebook containing all syntax regulations, markdown structures, and grammar rules required to build flawless slides.
2. **Added `mdslide llms` Command**: A new command that fetches and injects the `SYNTAX.md` rules directly into an AI agent's current active session.
3. **Updated Bundler Configuration (`tsup.config.ts`)**: Embedded the `SYNTAX.md` file path into the build pipeline so the rules file is packaged automatically during production builds.

### Related Issues

CLOSE: #126 

## Type of Change

- [ ] 🐛 Bug fix
- [x] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [x] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

- [x] I have linted my code using `bun run lint`.
- [x] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.

## Screenshots (if applicable)

_No visual UI changes; terminal/CLI output only._

## Additional Context

This feature ensures that LLM systems can instantly understand how to structure slides perfectly without hallucinating custom markers (like `::col::` or `<!-- layout -->`). It automates context feeding for developers working with AI assistants.

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **CLI**
  - Added `mdslide llms` to output the complete syntax and CLI reference for AI agents.
  - Added the canonical `SYNTAX.md` documentation covering authoring, layouts, annotations, advanced content, configuration, and CLI usage.

- **Core rendering engine**
  - No changes.

- **Parser**
  - No changes.

- **Shared packages**
  - Added Markdown module typings and configured `tsup` to bundle `.md` files as text.

- **Tests (Vitest & Cypress)**
  - No changes.

- **Tooling/CI**
  - Added automated changeset generation based on conventional commit messages.
  - Added a workflow to generate and commit changesets on pushes to `dev` and `main`.

Breaking changes: None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->