### PR TITLE
Fix: `autoChangeset.ts` skips changeset generation for merge commits

### DIFF
--- a/scripts/autoChangeset.ts
+++ b/scripts/autoChangeset.ts
@@ -124,17 +124,35 @@ if (isRunDirectly) {
     process.exit(0);
   }
 
-  // Get list of modified files in the latest commit
+  // Get list of modified files in the latest commit.
+  //
+  // NOTE: `git diff-tree -r HEAD` only works reliably for commits with a
+  // single parent. A merge commit (e.g. created when a PR is merged into
+  // `dev`) has TWO parents, and in that case `git diff-tree -r HEAD` prints
+  // nothing rather than guessing which parent to diff against. To handle
+  // merge commits correctly, we diff explicitly against the first parent
+  // (`HEAD^1`), which is the tip of the target branch before the merge.
+  // This also works fine for regular single-parent commits, since HEAD^1
+  // is just their one parent. The fallback handles the rare root-commit
+  // case where HEAD^1 doesn't exist at all.
   let modifiedFiles: string[] = [];
   try {
-    modifiedFiles = execSync('git diff-tree --no-commit-id --name-only -r HEAD')
+    modifiedFiles = execSync('git diff-tree --no-commit-id --name-only -r HEAD^1 HEAD')
       .toString()
       .trim()
       .split('\n')
       .filter(Boolean);
   } catch (error) {
-    console.error('Error getting modified files from git:', error);
-    process.exit(1);
+    try {
+      modifiedFiles = execSync('git diff-tree --no-commit-id --name-only -r HEAD')
+        .toString()
+        .trim()
+        .split('\n')
+        .filter(Boolean);
+    } catch (fallbackError) {
+      console.error('Error getting modified files from git:', fallbackError);
+      process.exit(1);
+    }
   }
 
   // Skip if the commit itself already contains a changeset file


### PR DESCRIPTION
## Description

### What does this PR do?
Fixes `scripts/autoChangeset.ts` so it correctly detects changed files for **merge commits**, not just single-parent commits.

Previously, the script used:
```
git diff-tree --no-commit-id --name-only -r HEAD
```
This only works when `HEAD` has a single parent. When a PR is merged into `dev`, GitHub creates a **merge commit** with two parents, and `git diff-tree` on a merge commit silently returns an empty file list instead of erroring. This caused `changedPackages.size` to be `0`, which made the script bail out early with:

```
No workspace packages were modified in the latest commit. Skipping changeset generation.
```

...even when the merged PR clearly modified package files. As a result, changesets were never generated for merged PRs, only for direct/squash commits.

**Fix:** diff `HEAD` against its first parent explicitly:
```
git diff-tree --no-commit-id --name-only -r HEAD^1 HEAD
```
This compares the state of `dev` before the merge (`HEAD^1`) to after the merge (`HEAD`), which correctly captures every file the PR introduced — whether `HEAD` is a merge commit or a regular commit. A `try/catch` fallback to the original single-arg `HEAD` diff is kept for the edge case of a repository's very first (parentless) commit.

### Related Issues
- Closes #ISSUE_NUMBER *(replace with actual issue number if one exists)*

## Type of Change
- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist
- [x] I have linted my code using `bun run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.

## Screenshots (if applicable)
_Before: Action log shows "No workspace packages were modified" despite the merged PR touching `packages/`. After: changeset file is generated correctly for the merged files._

## Additional Context
Root cause: `git diff-tree <single-commit>` implicitly diffs against a commit's sole parent, which is ambiguous (and therefore empty) for merge commits with two parents. Explicitly passing `HEAD^1 HEAD` removes that ambiguity and works uniformly for both merge and non-merge commits.

---

### Thank you for your contribution!
_We appreciate your efforts in making this project better._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Tooling/CI**
  - Updated autochangeset file detection to compare `HEAD^1` with `HEAD`, correctly capturing changes from merge commits.
  - Retained a fallback to the original `HEAD` diff for parentless initial commits.
  - Preserved existing changeset and workspace-package detection behavior.

Breaking changes: None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->