### PR TITLE
docs(core): add quick start section with install and usage example

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,6 +2,38 @@
 
 The core compilation, normalization, and rendering engine for `mdslide`. It orchestrates the transformation of a parsed Markdown AST into interactive, styled slide decks.
 
+## Quick Start
+
+Install the package:
+
+```bash
+npm install @mindfiredigital/mdslide-core
+# or
+bun add @mindfiredigital/mdslide-core
+```
+
+Use the `Compiler` class to compile a Markdown string into an HTML slide deck:
+
+```typescript
+import { Compiler } from '@mindfiredigital/mdslide-core';
+
+const compiler = new Compiler();
+const html = await compiler.compile(`
+# Hello World
+
+Welcome to mdslide!
+
+---
+
+## Slide Two
+
+- Bullet one
+- Bullet two
+`);
+
+console.log(html); // Full HTML presentation output
+```
+
 ## Compiler Architecture & Pipeline Flow
 
 The compilation process is managed by the central `Compiler` class and flows through the following pipeline:


### PR DESCRIPTION
### What does this PR do?

Adds a **Quick Start** section to the `@mindfiredigital/mdslide-core` package README, which was previously missing. The new section covers:

- Installation instructions via `npm` and `bun`
- A minimal TypeScript usage example showing how to instantiate the `Compiler` class and compile a Markdown string into an HTML slide deck

This makes it significantly easier for developers consuming the core package directly to get up and running without having to dig into the source code or internal documentation.

### Related Issues

- N/A

## Type of Change

- [ ] 🐛 Bug fix
- [ ] 🚀 New feature
- [x] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

- [x] I have linted my code using `bun run lint`.
- [x] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.

## Screenshots (if applicable)

_N/A — documentation-only change._

## Additional Context

The `packages/core/README.md` previously jumped straight into compiler architecture internals with no entry point for new users. This section is placed at the top of the document, before the architecture deep-dive, so it serves as a proper onboarding guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Core rendering engine
- Added a Quick Start section to the core package README.
- Documented npm and Bun installation commands.
- Added a TypeScript example demonstrating `Compiler` usage to generate an HTML slide deck.

Breaking changes: None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->