### PR TITLE
Fix/curl installer issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,14 @@ jobs:
         id: version
         run: echo "version=$(node -p 'require("./packages/cli/package.json").version')" >> $GITHUB_OUTPUT
 
+      - name: Generate checksums
+        working-directory: binaries
+        run: |
+          for f in *; do
+            sha256sum "$f" | awk '{print $1}' > "${f}.sha256"
+          done
+          ls -la
+
       - name: Upload binaries to GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/presentation-e2e.md
+++ b/presentation-e2e.md
@@ -20,3 +20,4 @@ This is the content on the second slide.
 ## Slide Three Title
 
 This is the content on the third slide.
+hello

--- a/presentation-e2e.md
+++ b/presentation-e2e.md
@@ -20,4 +20,3 @@ This is the content on the second slide.
 ## Slide Three Title
 
 This is the content on the third slide.
-hello


### PR DESCRIPTION
## Pull Request Title
**Fix: Generate missing `.sha256` checksum files during release upload**

---

## Description

### What does this PR do?
The install scripts (`install.sh` / `install.ps1`) fetch a `.sha256` file alongside every downloaded binary to verify integrity before installation. However, the release workflow never generated these checksum files, so every published release was missing them. This caused `curl -fsSL https://mindfiredigital.github.io/mdslide/installer | bash` to fail at the checksum verification step with a `404` on the `.sha256` asset.

This PR adds a `Generate checksums` step to the `upload-release` job, run right after all platform binaries are downloaded and merged into the `binaries/` directory, and before they're uploaded to the GitHub Release. It computes a SHA-256 hash for every binary and writes it to a matching `<binary>.sha256` file, which then gets picked up by the existing `files: binaries/*` glob in the release upload step.

```yaml
      - name: Generate checksums
        working-directory: binaries
        run: |
          for f in *; do
            sha256sum "$f" | awk '{print $1}' > "${f}.sha256"
          done
          ls -la
```

### Related Issues
- Closes #ISSUE_NUMBER (if applicable)

## Type of Change
- [x] 🐛 Bug fix
- [ ] 🚀 New feature
- [ ] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [x] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist
_Please ensure the following have been completed before submitting:_
- [ ] I have linted my code using `bun run lint`.
- [ ] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR.

## Screenshots (if applicable)
N/A — CI/CD workflow change, no visible UI output. Verified locally that `sha256sum <file> | awk '{print $1}'` produces a single-hash-per-line output matching the format expected by `install.sh` and `install.ps1`.

## Additional Context
- Since this bug affects all previously published releases (they're missing `.sha256` assets), existing install-script failures won't resolve until a new release is cut with this fix. Maintainers may want to manually back-fill `.sha256` files on the current latest release via `gh release upload` as a stopgap.
- No changes were needed to `install.sh` / `install.ps1` — they already expected this checksum format correctly; the workflow was simply never producing it.

---
### Thank you for your contribution!
_We appreciate your efforts in making this project better._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Tooling/CI
- Release workflow now generates `.sha256` checksum files for published binaries.
- Checksum files are included in GitHub Releases via the existing upload glob, fixing installer failures caused by missing assets.

Breaking changes: None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->