### PR TITLE
ci: add SHA-256 checksums to release binaries and fix curl installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,14 @@ jobs:
         id: version
         run: echo "version=$(node -p 'require("./packages/cli/package.json").version')" >> $GITHUB_OUTPUT
 
+      - name: Generate checksums
+        working-directory: binaries
+        run: |
+          for f in *; do
+            sha256sum "$f" | awk '{print $1}' > "${f}.sha256"
+          done
+          ls -la
+
       - name: Upload binaries to GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/presentation-e2e.md
+++ b/presentation-e2e.md
@@ -20,3 +20,4 @@ This is the content on the second slide.
 ## Slide Three Title
 
 This is the content on the third slide.
+hello

--- a/presentation-e2e.md
+++ b/presentation-e2e.md
@@ -20,4 +20,3 @@ This is the content on the second slide.
 ## Slide Three Title
 
 This is the content on the third slide.
-hello


### PR DESCRIPTION
### What does this PR do?

This PR merges the latest `dev` changes into `main`, delivering two CI/CD improvements:

1. **SHA-256 checksum generation** — The release workflow (`release.yml`) now generates a `.sha256` file for every binary produced during a GitHub Release. This allows downstream users and scripts to verify download integrity without relying on external tooling.

2. **Fix curl-based installer** — Resolves a breakage in the `curl | bash` installer flow that prevented users from installing mdslide via the shell script.

> These changes do **not** touch any package source code. The automated changeset workflow (`auto-changeset.yml`) detected a `patch`-level bump for `@mindfiredigital/mdslide-core` based on conventional commits and has already generated the changeset file (`.changeset/auto-114aa45.md`).

### Related Issues

- N/A (CI/CD maintenance)

---

## Type of Change

- [x] 🔧 Configuration or CI/CD change
- [x] 🐛 Bug fix _(curl installer regression)_

---

## Checklist

- [x] I have linted my code using `bun run lint`.
- [x] I have updated the documentation as needed.
- [ ] I have added or updated tests for the changes in this PR. *(CI changes — no unit tests applicable)*

---

## Changes Summary

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Added `Generate checksums` step — loops over all binaries and writes `<binary>.sha256` files before upload |
| `.changeset/auto-114aa45.md` | Auto-generated by `scripts/autoChangeset.ts` via the `auto-changeset.yml` workflow (`patch` bump for `mdslide-core`) |
| `packages/cli/package.json` | Version reverted to `1.0.1` in `dev` (pre-bump state, bump will happen on release) |
| `packages/core/package.json` | Version reverted to `0.0.2` in `dev` (pre-bump state, bump will happen on release) |
| `packages/cli/CHANGELOG.md` | Rollback of entries not yet released |
| `packages/core/CHANGELOG.md` | Rollback of entries not yet released |

---

## How the Auto-Changeset Workflow Integrates

The repo uses [`scripts/autoChangeset.ts`](../../scripts/autoChangeset.ts) driven by [`.github/workflows/auto-changeset.yml`](../../.github/workflows/auto-changeset.yml).

- Triggers on every push to `dev` or `main`.
- Reads conventional commit messages (`feat`, `fix`, `ci!`, etc.) since the last merge point.
- Maps changed packages → bump type (`major` / `minor` / `patch`).
- Writes a `.changeset/*.md` file and auto-commits it (bot commit is skipped to prevent loops).

The changeset in this PR (`auto-114aa45.md`) was generated automatically. The actual version bump and CHANGELOG append will occur when the **Release workflow** runs on `main` after merge.

---

## Screenshots (if applicable)

_No UI changes._

---

## Additional Context

- The `.sha256` files are generated using `sha256sum` inside the `binaries/` working directory and will appear as release assets alongside the binaries on the GitHub Releases page.
- The curl installer fix addresses a path/quoting issue that caused the script to fail on some shells when piped directly via `curl | bash`.
- All other `dev` commits (`docs(root): somehting`) are documentation-only and carry no functional risk.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Tooling/CI**
  - Updated the release workflow to generate and upload SHA-256 checksum files for each release binary.
  - Fixed path/quoting issues in the `curl | bash` installer flow.
  - Rolled package versions and unreleased changelog entries back to pre-release values.
  - Added an automatically generated changeset for `@mindfiredigital/mdslide-core`.

- **CLI**
- **Core rendering engine**
- **Parser**
- **Shared packages**
- **Tests (Vitest & Cypress)**

Breaking changes: None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->